### PR TITLE
refactor(tablet): move to ox_lib modules and finish SIM-server support

### DIFF
--- a/client/bridge.lua
+++ b/client/bridge.lua
@@ -1,40 +1,25 @@
--- Request/reply transport to sd-phone's NUI callback registry.
---
--- sd-phone/client/companion.lua listens for 'sd-phone:client:companion:invoke' (token, action,
--- payload), runs its own recorded handler for that action, and answers with
--- 'sd-phone:client:companion:reply' (token, result). Client-side TriggerEvent dispatches to
--- handlers in every resource on this client, so the two events are all the transport there is -
--- no net traffic, no serialisation beyond what the event system already does.
---
--- The reply is ASYNCHRONOUS and must be treated as such. sd-phone's proxied callbacks sit on
--- `lib.callback.await`, which yields; the invoke TriggerEvent therefore returns to us long before
--- the answer exists. A handler that does no server work, on the other hand, answers INSIDE the
--- TriggerEvent call - so the pending entry has to be in the map before the event is fired, and
--- both orderings have to be safe. They are: the map is written first, and every path answers
--- through a one-shot closure.
+-- Request/reply transport to sd-phone's companion callback seam, over client-local TriggerEvents.
+-- The reply is async, but a handler with no server work answers INSIDE the invoke - so the pending
+-- entry is written first and every path answers through a one-shot closure.
 
 ---@type string The resource we borrow callbacks from.
 local PHONE <const> = 'sd-phone'
----@type integer Watchdog window. Generous on purpose: an sd-phone callback can be a database
----round-trip on a loaded server, and answering early would show the player a false failure for a
----request that then succeeds. This exists so the UI can never hang forever, not to enforce a
----latency budget.
+---@type integer Watchdog window; generous because an sd-phone callback can be a DB round-trip.
 local TIMEOUT_MS <const> = 15000
 
 ---@type table Module table; returned at end of file.
 local bridge = {}
 
----@type table<string, { cb: fun(result: any), action: string }> Outstanding requests by token.
+---@type table<string, { cb: fun(result: any), action: string, expires: integer }> Pending by token.
 local pending = {}
 ---@type integer Monotonic request counter; never reused within a session.
 local seq = 0
----@type string Token namespace. The reply event is broadcast to the whole client, so a second
----companion device's replies land in our handler too - prefixing with the resource name means our
----tokens can never collide with theirs, and theirs never match our pending map.
+---@type boolean True while the expiry sweeper thread is alive.
+local sweeping = false
+---@type string Token namespace; replies are broadcast, so another companion's can never collide.
 local PREFIX <const> = GetCurrentResourceName() .. ':'
 
----Resolves one outstanding request. Unknown tokens are another companion's (or a late reply to a
----request the watchdog already answered) and are ignored.
+---Resolves one outstanding request; unknown tokens are another companion's, or already expired.
 ---@param token any token we minted and echoed out
 ---@param result any handler response
 AddEventHandler('sd-phone:client:companion:reply', function(token, result)
@@ -44,9 +29,28 @@ AddEventHandler('sd-phone:client:companion:reply', function(token, result)
     entry.cb(result)
 end)
 
----Runs one of sd-phone's NUI callbacks on this device's behalf and hands the response back.
----`cb` is called EXACTLY once: by the reply, by the watchdog, or immediately when sd-phone isn't
----running to be asked.
+---Expires overdue requests; one thread rather than an uncancellable timer per forwarded action.
+local function startSweeper()
+    if sweeping then return end
+    sweeping = true
+    CreateThread(function()
+        -- Nothing yields between the condition going false and the flag clearing, so no invoke can
+        -- arm a sweeper that is on its way out.
+        while next(pending) do
+            Wait(1000)
+            local now = GetGameTimer()
+            for token, entry in pairs(pending) do
+                if now >= entry.expires then
+                    pending[token] = nil
+                    entry.cb({ success = false, message = 'No response' })
+                end
+            end
+        end
+        sweeping = false
+    end)
+end
+
+---Runs one of sd-phone's NUI callbacks on this device's behalf; `cb` fires EXACTLY once.
 ---@param action string NUI action name as sd-phone registered it
 ---@param payload any handler payload
 ---@param cb fun(result: any) response sink - the NUI callback's own cb
@@ -59,8 +63,7 @@ function bridge.invoke(action, payload, cb)
         cb(result)
     end
 
-    -- A stopped or restarting sd-phone would swallow the invoke and leave the UI on a spinner for
-    -- the whole watchdog window; failing now is both faster and truthful.
+    -- A stopped sd-phone would swallow the invoke and leave the UI spinning for the whole window.
     if GetResourceState(PHONE) ~= 'started' then
         answer({ success = false, message = 'Phone service unavailable', unsupported = true })
         return
@@ -68,19 +71,14 @@ function bridge.invoke(action, payload, cb)
 
     seq = seq + 1
     local token = PREFIX .. seq
-    pending[token] = { cb = answer, action = action }
+    pending[token] = { cb = answer, action = action, expires = GetGameTimer() + TIMEOUT_MS }
 
     TriggerEvent('sd-phone:client:companion:invoke', token, action, payload)
 
-    -- Already gone: the handler answered inside the TriggerEvent above (no server round-trip).
-    -- Arming a watchdog for it would keep a closure alive for 15s for nothing.
+    -- Already answered inside the TriggerEvent above, so there is nothing left to watch.
     if not pending[token] then return end
 
-    SetTimeout(TIMEOUT_MS, function()
-        if not pending[token] then return end
-        pending[token] = nil
-        answer({ success = false, message = 'No response' })
-    end)
+    startSweeper()
 end
 
 ---Number of requests still waiting on sd-phone. Debug/diagnostics only.
@@ -91,8 +89,7 @@ function bridge.pendingCount()
     return n
 end
 
--- sd-phone stopping mid-request takes its reply with it. Fail every outstanding call at once
--- rather than leaving the UI to discover it one 15s watchdog at a time.
+-- sd-phone stopping mid-request takes its reply with it; fail every outstanding call at once.
 AddEventHandler('onResourceStop', function(resource)
     if resource ~= PHONE then return end
     local outstanding = pending

--- a/client/main.lua
+++ b/client/main.lua
@@ -17,6 +17,11 @@ local cfg <const> = config.Tablet
 ---@type string The resource we borrow everything from.
 local PHONE <const> = 'sd-phone'
 
+-- Every string this resource puts in front of a player comes from locales/<lang>.json. The React
+-- app has its own catalog keyed off config.Locale; this is only the Lua half - refusals, the
+-- notify title, and the two keybind labels FiveM shows in its binding menu.
+lib.locale()
+
 -- Apps disabled in configs/apps.lua never reach the NUI; built once, the catalog is static per boot.
 ---@type table[] Enabled app entries, config order preserved.
 local ENABLED_APPS = {}
@@ -100,10 +105,13 @@ local cameraCursorFree = false
 ---@type fun() Tablet close; assigned further down, referenced by threads defined before it.
 local CloseTablet
 
----Prints debug output when config.Debug is enabled.
+---Debug breadcrumb. Two ways to turn it on, because they answer different questions:
+---config.Debug is the resource's own switch and prints at info so it shows with no setup, while
+---`setr ox:printlevel:sd-tablet debug` turns the same output on live, without editing a config.
 ---@param ... any values to print
 local function debugPrint(...)
-    if config.Debug then print('[sd-tablet:client]', ...) end
+    if config.Debug then return lib.print.info(...) end
+    lib.print.debug(...)
 end
 
 ---Shows an on-screen toast; ox_lib is a hard dependency, so it is always the backend here.
@@ -111,8 +119,10 @@ end
 ---@param kind string|nil 'error' | 'inform' | 'success'
 local function notify(description, kind)
     lib.notify({
-        id          = math.random(1, 999999),
-        title       = 'Tablet',
+        -- UUIDv7, not a random int: ox_lib treats the id as a dedupe key, so a collision replaces
+        -- a toast the player is still reading.
+        id          = lib.uuid.generate(),
+        title       = locale('tablet'),
         description = description,
         type        = kind or 'inform',
         position    = 'top-right',
@@ -327,6 +337,15 @@ local function updatePose()
     broadcastHoldState()
 end
 
+-- A respawn or a ped-model change hands the player a NEW ped, and our prop is still welded to the
+-- old one - which the game does not necessarily delete, so it can be left hanging in the world.
+-- The clip re-applies itself on the tick below, but the orphaned prop never would. ox_lib already
+-- tracks the ped for `cache.ped`, so this subscribes to that change rather than adding a poll.
+lib.onCache('ped', function()
+    removeProp()
+    if tabletState.open then updatePose() end
+end)
+
 -- Re-applies the held clip if the game clears it: an upper-body secondary task loses to sprints,
 -- jumps and vehicle transitions, and this device is explicitly usable while walking. Backs off to
 -- a 1s tick while stowed, since the thread lives for the whole session either way.
@@ -371,6 +390,44 @@ end
 ---@type boolean True while the per-frame input thread is running.
 local inputThreadRunning = false
 
+-- The four control sets this device suppresses, as data. They are handed to ox_lib's
+-- lib.disableControls, which keeps ONE refcounted set and re-asserts all of it in a single call
+-- per frame - so the thread below toggles a group when the state changes rather than issuing the
+-- same two dozen DisableControlAction calls every frame regardless.
+
+---@type integer[] INPUT_FRONTEND_PAUSE and its alternate; held whenever the tablet is on screen.
+local CONTROLS_PAUSE <const> = { 199, 200 }
+
+---@type integer[] Combat, melee, weapon-wheel, cover, chat - and the scroll-wheel fall-throughs
+---under keep-input, because the UI owns the wheel.
+local CONTROLS_MOVEMENT <const> = {
+    24, 25, 37, 106, 245, 246, 257, 263, 264, 140, 141, 142, 143,
+    14, 15, 16, 17, 81, 82, 83, 84, 85, 99, 100,
+}
+
+---@type integer[] Mouse-look. Dropped while the Camera app aims the lens, or it would be immovable.
+local CONTROLS_LOOK <const> = { 1, 2 }
+
+---@type integer[] The number row, which GTA binds to weapon slots while a digit field is focused.
+local CONTROLS_DIGITS <const> = { 157, 158, 159, 160, 161, 162, 163, 164, 165, 166 }
+
+---@type table<table, true> Groups currently added to lib.disableControls.
+local appliedControls = {}
+
+---Adds or removes a group exactly once per state change; Add/Remove are refcounted, so an
+---unbalanced pair would leave a control disabled for the rest of the session.
+---@param group integer[]
+---@param wanted boolean
+local function setControlGroup(group, wanted)
+    if wanted == (appliedControls[group] or false) then return end
+    appliedControls[group] = wanted or nil
+    if wanted then
+        lib.disableControls:Add(group)
+    else
+        lib.disableControls:Remove(group)
+    end
+end
+
 ---Runs ONE per-frame thread per open: holds the pause control down unconditionally, and with
 ---AllowMovement on also suppresses combat, mouse-look, weapon-wheel and chat as sd-phone does.
 local function startInputThread()
@@ -381,66 +438,48 @@ local function startInputThread()
         -- flag about to clear, which would leave an open tablet suppressing nothing.
         while true do
             while tabletState.open do
-                DisableControlAction(0, 199, true) -- INPUT_FRONTEND_PAUSE
-                DisableControlAction(0, 200, true) -- INPUT_FRONTEND_PAUSE_ALTERNATE
+                setControlGroup(CONTROLS_PAUSE, true)
 
+                ---@type boolean Whether the movement suppression applies this frame.
+                local suppress = false
                 if cfg.AllowMovement then
                     if IsPauseMenuActive() then
                         CloseTablet()
-                    elseif (not typingInTablet or typingNumeric) and not nativeCellCam() then
-                        DisablePlayerFiring(cache.playerId, true)
-                        -- The Camera app's Alt toggle aims the lens with the mouse; suppressing
-                        -- mouse-look while it has would make the lens immovable.
-                        if not lookMode and not cameraCursorFree then
-                            DisableControlAction(0, 1, true)
-                            DisableControlAction(0, 2, true)
-                        end
-                        DisableControlAction(0, 24, true)
-                        DisableControlAction(0, 25, true)
-                        DisableControlAction(0, 257, true)
-                        DisableControlAction(0, 263, true)
-                        DisableControlAction(0, 264, true)
-                        DisableControlAction(0, 140, true)
-                        DisableControlAction(0, 141, true)
-                        DisableControlAction(0, 142, true)
-                        DisableControlAction(0, 143, true)
-                        DisableControlAction(0, 37, true)
-                        DisableControlAction(0, 106, true)
-                        DisableControlAction(0, 245, true)
-                        DisableControlAction(0, 246, true)
-                        -- Scroll-wheel fall-throughs under keep-input: the UI owns the wheel.
-                        DisableControlAction(0, 14, true)
-                        DisableControlAction(0, 15, true)
-                        DisableControlAction(0, 16, true)
-                        DisableControlAction(0, 17, true)
-                        DisableControlAction(0, 81, true)
-                        DisableControlAction(0, 82, true)
-                        DisableControlAction(0, 83, true)
-                        DisableControlAction(0, 84, true)
-                        DisableControlAction(0, 85, true)
-                        DisableControlAction(0, 99, true)
-                        DisableControlAction(0, 100, true)
-                        if typingNumeric then
-                            -- Digit pad up: the number row must not fire GTA weapon-slot binds.
-                            for control = 157, 166 do
-                                DisableControlAction(0, control, true)
-                            end
-                        end
+                    else
+                        suppress = (not typingInTablet or typingNumeric) and not nativeCellCam()
                     end
                 end
+
+                setControlGroup(CONTROLS_MOVEMENT, suppress)
+                -- The Camera app's Alt toggle aims the lens with the mouse; suppressing mouse-look
+                -- while it has would make the lens immovable.
+                setControlGroup(CONTROLS_LOOK, suppress and not lookMode and not cameraCursorFree)
+                setControlGroup(CONTROLS_DIGITS, suppress and typingNumeric)
+
+                -- Not a control, so it stays a native and stays inside the frame loop.
+                if suppress then DisablePlayerFiring(cache.playerId, true) end
+
+                lib.disableControls()
                 Wait(0)
             end
 
             -- Held a few frames past the close, or the closing keypress opens the escape menu.
+            -- Pause is re-asserted rather than assumed: the loop above always adds it in practice,
+            -- but the hold is the one suppression that must not depend on how we got here.
+            setControlGroup(CONTROLS_PAUSE, true)
+            setControlGroup(CONTROLS_MOVEMENT, false)
+            setControlGroup(CONTROLS_LOOK, false)
+            setControlGroup(CONTROLS_DIGITS, false)
+
             local held = 0
             while held < 15 and not tabletState.open do
-                DisableControlAction(0, 199, true)
-                DisableControlAction(0, 200, true)
+                lib.disableControls()
                 held = held + 1
                 Wait(0)
             end
             if not tabletState.open then break end
         end
+        setControlGroup(CONTROLS_PAUSE, false)
         -- No yield since the break, so an open cannot be refused by a flag about to clear.
         inputThreadRunning = false
     end)
@@ -554,27 +593,27 @@ local function canOpen()
     if tabletState.open then return false end
 
     if GetResourceState(PHONE) ~= 'started' then
-        return false, 'The tablet can\'t connect right now.'
+        return false, locale('cannot_connect')
     end
 
     -- One switch disables both devices: a script taking the phone away means no screen, not a spare.
     local gotDisabled, disabled = phoneExport('isDisabled')
     if gotDisabled and disabled == true then
-        return false, 'You can\'t use your tablet right now.'
+        return false, locale('cannot_use')
     end
 
     -- No SIM check: the tablet borrows the identity of the SIM in the phone you carry, exactly as
     -- it borrows everything else, so a request already answers as the right number. With no SIM
     -- the shared UI shows its own No Service screen, the same as the phone does.
     if cfg.BlockWhileDead and IsEntityDead(cache.ped) then
-        return false, 'You can\'t use your tablet right now.'
+        return false, locale('cannot_use')
     end
     if cfg.BlockWhileSwimming and IsPedSwimming(cache.ped) then
-        return false, 'You can\'t use your tablet while swimming.'
+        return false, locale('cannot_use_swimming')
     end
     -- cache.vehicle is false on foot; seat -1 is the driver's.
     if cfg.BlockWhileDriving and cache.vehicle and cache.seat == -1 then
-        return false, 'Not while you\'re driving.'
+        return false, locale('cannot_use_driving')
     end
 
     return true
@@ -711,7 +750,7 @@ local function ToggleTablet()
     -- timeout resolves to nil - which the type check below already reports as a refusal.
     local res = lib.callback.await('sd-tablet:server:resolveOpen', 10000, currentColor)
     if type(res) ~= 'table' or res.ok ~= true then
-        notify((type(res) == 'table' and res.message) or 'You don\'t have a tablet.', 'error')
+        notify((type(res) == 'table' and res.message) or locale('no_tablet'), 'error')
         return
     end
     if res.color and TABLET_COLORS[res.color] then currentColor = res.color end
@@ -720,7 +759,7 @@ end
 
 lib.addKeybind({
     name        = 'sdtablet_toggle',
-    description = 'Toggle Tablet',
+    description = locale('keybind_toggle'),
     defaultKey  = cfg.Keybind,
     onPressed   = ToggleTablet,
 })
@@ -728,7 +767,7 @@ lib.addKeybind({
 -- Hold-to-look: press frees the mouse for camera rotation, release restores the cursor.
 lib.addKeybind({
     name        = 'sdtablet_look',
-    description = 'Tablet: Hold to look around',
+    description = locale('keybind_look'),
     defaultKey  = cfg.LookKeybind,
     onPressed   = enterLookMode,
     onReleased  = exitLookMode,
@@ -797,9 +836,10 @@ local LOCAL_HANDLERS = {
 }
 
 rpc.bind(LOCAL_HANDLERS)
-if config.Debug then
-    rpc.setTrace(function(kind, action) debugPrint(kind, action) end)
-end
+-- Installed unconditionally now that debugPrint is level-filtered: with config.Debug off the
+-- trace costs one filtered call per action and `setr ox:printlevel:sd-tablet debug` turns it on
+-- live, which is the whole point of not having to restart to see a forward.
+rpc.setTrace(function(kind, action) debugPrint(kind, action) end)
 
 -- The FLIP only ever travels page -> Lua as this callback, so watching it through is the one place
 -- this side can learn the lens. The app always enters on the rear one, and both ways to flip end here.

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,23 +1,7 @@
--- sd-tablet client shell.
---
--- This resource contains no apps. sd-phone's client owns every NUI callback, every server
--- round-trip and every live push the shared React bundle needs, and the tablet borrows all of it
--- across the companion seam in sd-phone/client/companion.lua. What lives here is only what is
--- true of THIS DEVICE and nothing else:
---
---   * its own NUI frame, its own focus, its own open/close lifecycle
---   * the sd-phone:open payload that tells the shared bundle it is a tablet
---   * the hand prop and the hold clip
---   * device-local NUI callbacks (close, unlock, typing, flashlight...) that must never be
---     forwarded, or they would drive the phone's hardware from the tablet's screen
---
--- Everything else - messages, mail, contacts, installed apps, settings, the lot - is the same
--- server-side character on the same tables, reached through the same handlers. That is not a
--- synchronisation feature; there is only one copy of the data and both devices read it.
---
--- The one thing the tablet cannot do is place or answer a voice call. That refusal lives on
--- sd-phone's side of the seam (see its DENY list), so it holds even for a hand-edited build;
--- client/policy.lua repeats it here only so a refused action never leaves the resource.
+-- sd-tablet client shell: this device's NUI frame, focus, open/close lifecycle, hand prop, hold
+-- clip and the device-local callbacks that must never be forwarded. Every app, server round-trip
+-- and live push belongs to sd-phone and is borrowed across the companion seam - there is one copy
+-- of the data and both devices read it. Voice calls are refused on sd-phone's side of the seam.
 
 ---@type table sd-phone invoke transport (client.bridge): token-matched request/reply.
 local bridge = require 'client.bridge'
@@ -33,8 +17,7 @@ local cfg <const> = config.Tablet
 ---@type string The resource we borrow everything from.
 local PHONE <const> = 'sd-phone'
 
--- Apps disabled in configs/apps.lua never reach the NUI, so neither the home screen nor the App
--- Store can show them. Built once - the catalog is static per boot.
+-- Apps disabled in configs/apps.lua never reach the NUI; built once, the catalog is static per boot.
 ---@type table[] Enabled app entries, config order preserved.
 local ENABLED_APPS = {}
 ---@type string[] Dock ids with disabled apps dropped.
@@ -52,17 +35,13 @@ do
     end
 end
 
--- The catalog above is what this SERVER has; what this PLAYER may see also depends on the job they
--- hold, which only sd-phone's server knows. Asked on every open, so switching job on a multijob
--- server puts the right terminal on the home screen with no event to miss.
---
--- The callback is sd-phone's, called directly rather than through the companion seam: this decides
--- what goes INTO our open payload, so it has to be answered before the frame exists to forward
--- anything. A server without it (an older sd-phone) leaves the catalog untouched.
+-- What this PLAYER may see also depends on their job, which only sd-phone's server knows; asked on
+-- every open so a multijob switch needs no event. Called directly rather than through the seam,
+-- because it decides what goes INTO the open payload - an older sd-phone leaves the catalog alone.
 ---@return table[] apps
 ---@return string[] dock
 local function visibleApps()
-    local ok, hidden = pcall(lib.callback.await, 'sd-phone:server:apps:hidden', false)
+    local ok, hidden = pcall(lib.callback.await, 'sd-phone:server:apps:hidden', 5000)
     if not ok or type(hidden) ~= 'table' or #hidden == 0 then return ENABLED_APPS, ENABLED_DOCK end
 
     local drop = {}
@@ -79,9 +58,8 @@ local function visibleApps()
     return apps, dock
 end
 
--- Number display config for the NUI. Format keys are stringified deliberately: a Lua table whose
--- integer keys run contiguously from 1 encodes as a JSON ARRAY, which would land in the UI
--- off-by-one, so this guarantees an object either way. Same treatment as sd-phone's.
+-- Format keys are stringified so the table can never encode as a JSON array, which would land in
+-- the UI off-by-one. Same treatment as sd-phone's.
 ---@type { formats: table<string, string>, length: integer }
 local NUMBER_FORMAT = {}
 do
@@ -100,23 +78,21 @@ local tabletState = {
     battery = cfg.StatusBar.BatteryStart,
 }
 
----@type integer Wall-clock ms of the session start (re-stamped on character load); the Health
----app's "time awake" anchor. Stamped the same way sd-phone stamps its own, from the same events,
----so the two devices agree without either having to ask the other.
+---@type integer Session-start ms; the Health app's "time awake" anchor, stamped from the same
+---events sd-phone uses so the two devices agree without asking each other.
 local SESSION_START_MS = GetCloudTimeAsInt() * 1000
 
 ---@type boolean True while a UI text field is focused.
 local typingInTablet = false
----@type boolean True while the focused field is digit-only (PIN pads): keep-input stays on so the
----player can move, and the digit weapon binds are suppressed instead.
+---@type boolean True while the focused field is digit-only; keep-input stays on and the digit
+---weapon binds are suppressed instead, so the player can still move.
 local typingNumeric = false
 ---@type boolean True while the hold-to-look keybind has released the cursor for camera control.
 local lookMode = false
 ---@type boolean True while a forwarded sd-phone camera surface owns the view on our behalf.
 local cameraActive = false
----@type boolean True while that surface is framing with the REAR lens, i.e. the player - and
----anything in their hands - must stay out of their own shot. Tracked from the lens callback the UI
----forwards; see the rpc.watch wiring further down.
+---@type boolean True while that surface frames with the REAR lens, i.e. the player and anything in
+---their hands must stay out of the shot. Tracked from the rpc.watch wiring further down.
 local cameraRearLens = false
 ---@type boolean True while the Camera app has handed the mouse to the game to aim the lens.
 local cameraCursorFree = false
@@ -130,9 +106,7 @@ local function debugPrint(...)
     if config.Debug then print('[sd-tablet:client]', ...) end
 end
 
----Shows an on-screen toast. ox_lib is a hard dependency of both resources, so it is always the
----backend here - unlike sd-phone, which has a whole bridge because its notify reaches players
----from the server too.
+---Shows an on-screen toast; ox_lib is a hard dependency, so it is always the backend here.
 ---@param description string
 ---@param kind string|nil 'error' | 'inform' | 'success'
 local function notify(description, kind)
@@ -146,37 +120,27 @@ local function notify(description, kind)
     })
 end
 
----Calls an sd-phone client export, tolerating one that does not exist. Several readings the open
----payload wants (service bars, Wi-Fi networks) have exports; a couple do not yet, and calling a
----missing export raises rather than returning nil. Wrapping the call means a newer sd-phone that
----adds one is picked up with no change here, and an older one falls back to config.
+---Calls an sd-phone client export, tolerating one that does not exist - a missing export raises
+---rather than returning nil, so a newer sd-phone is picked up and an older one falls back to config.
 ---@param name string export name
 ---@param ... any arguments
 ---@return boolean ok, any value
+local function callPhoneExport(name, ...)
+    return exports[PHONE][name](exports[PHONE], ...)
+end
+
 local function phoneExport(name, ...)
     if GetResourceState(PHONE) ~= 'started' then return false, nil end
-    -- The INDEX is what raises on a missing export ("No such export x in resource y"), not the
-    -- call, so it has to happen inside the pcall - hence the closure rather than pcall'ing the
-    -- looked-up function directly.
-    local ok, res = pcall(function(...) return exports[PHONE][name](exports[PHONE], ...) end, ...)
+    local ok, res = pcall(callPhoneExport, name, ...)
     if not ok then return false, nil end
     return true, res
 end
 
 -------------------------------------------------------------------- capability reads
 
----Whether sd-phone is running unique phones / SIM cards.
----
----This is the one mode a tablet cannot participate in. Under SIM mode the acting identity is
----resolved from the SIM sitting in the player's ACTIVE PHONE, so every server callback the tablet
----forwards would answer for whichever phone they last opened - or for nothing at all if they are
----not carrying one. A tablet has no SIM tray and no device identity of its own, so rather than
----opening a device that shows the wrong player's data (or an empty one), it refuses.
----
----sd-phone exposes isSimModeActive as a SERVER export only, and the flag settles several seconds
----into boot behind an inventory-support probe. sd-tablet's server therefore publishes it as
----global state; the pcall'd client export is checked first so a future sd-phone that adds one
----takes precedence.
+---Whether sd-phone is running unique phones / SIM cards. Not a refusal - it rides in the open
+---payload so the shared UI can tell "no SIM in the phone you carry" apart from "this server has no
+---SIMs". Read from our server's global state, preferring a client export if a future sd-phone adds one.
 ---@return boolean
 local function simModeActive()
     local ok, res = phoneExport('isSimModeActive')
@@ -184,40 +148,53 @@ local function simModeActive()
     return GlobalState.sdTabletSimMode == true
 end
 
----Cosmetic signal bars for the status bar. sd-phone's live cell-service model owns the real
----number whenever masts are configured; with none, service is always full and the config value is
----the honest answer.
+---@type boolean|nil Whether sd-phone has cell masts configured; nil until answered.
+local towersConfigured = nil
+---@type boolean|nil Whether sd-phone has Wi-Fi networks configured; nil until answered.
+local wifiSystemOn = nil
+---@type boolean|nil Whether sd-phone reports Bluetooth configured; nil until answered.
+local bluetoothSystemOn = nil
+
+---Cosmetic signal bars; sd-phone's live model owns the real number whenever masts are configured.
 ---@return integer bars 0..4
 local function signalBars()
-    local ok, towers = phoneExport('getCellTowers')
-    if ok and type(towers) == 'table' and #towers > 0 then
+    if towersConfigured == nil then
+        local ok, towers = phoneExport('getCellTowers')
+        if ok then towersConfigured = type(towers) == 'table' and #towers > 0 end
+    end
+    if towersConfigured then
+        -- Not cached: this one is the LIVE reading, and it moves with the player.
         local gotBars, bars = phoneExport('getServiceBars')
         if gotBars and type(bars) == 'number' then return bars end
     end
     return cfg.StatusBar.SignalBars
 end
 
----Whether this server runs Wi-Fi at all (as opposed to whether the player is on it). Empty
----network list means the system is switched off in sd-phone's configs/wifi.lua.
+---Whether this server runs Wi-Fi at all; an empty network list means it is off in sd-phone's config.
 ---@return boolean
 local function wifiConfigured()
-    local ok, networks = phoneExport('getWifiNetworks')
-    return ok and type(networks) == 'table' and #networks > 0
+    if wifiSystemOn == nil then
+        local ok, networks = phoneExport('getWifiNetworks')
+        if ok then wifiSystemOn = type(networks) == 'table' and #networks > 0 end
+    end
+    return wifiSystemOn == true
 end
 
----Whether this server runs Bluetooth at all. No sd-phone export answers this today, so the config
----mirror is the fallback; see configs/tablet.lua.
+---Whether this server runs Bluetooth at all; no sd-phone export answers it yet, so config is used.
 ---@return boolean
 local function bluetoothConfigured()
-    local ok, res = phoneExport('isBluetoothConfigured')
-    if ok and type(res) == 'boolean' then return res end
+    if bluetoothSystemOn == nil then
+        local ok, res = phoneExport('isBluetoothConfigured')
+        if ok and type(res) == 'boolean' then bluetoothSystemOn = res end
+    end
+    if bluetoothSystemOn ~= nil then return bluetoothSystemOn end
     return cfg.StatusBar.BluetoothConfigured ~= false
 end
 
 -------------------------------------------------------------------- hold pose
 
----@type integer Flags for the reading pose: loop, resist interruption, upper body only, secondary
----task. Upper-body plus secondary is what leaves the legs free to walk.
+---@type integer Reading pose: LOOPING | NOT_INTERRUPTABLE | UPPERBODY | SECONDARY - the last two
+---are what leave the legs free to walk.
 local POSE_FLAGS <const> = 1 | 8 | 16 | 32
 ---@type integer|nil Handle of the attached tablet prop, nil while stowed.
 local prop = nil
@@ -225,32 +202,22 @@ local prop = nil
 ---@type string Colour the tablet is currently held in; always a key of TABLET_COLORS.
 local currentColor = cfg.DefaultColor or 'black'
 
----@type table<string, true> Colours any configured item can open, used to whitelist every colour
----that arrives from the server or off another player's statebag.
+---@type table<string, true> Whitelist for every colour arriving from the server or a statebag.
 local TABLET_COLORS = {}
 for _, entry in ipairs(cfg.Items or {}) do TABLET_COLORS[entry.color] = true end
 if not TABLET_COLORS[currentColor] then TABLET_COLORS[currentColor] = true end
 
----Whether sd-phone framed the current shot with the NATIVE cell-cam rather than with its own
----scripted camera. The two are nothing alike from this side: the native pins the ped at engine
----level, plays a pose of its own and spawns its own phone prop, while the scripted one only takes
----the view and leaves the ped entirely alone. So this one question answers both "must keep-input
----go off" and "must our hold pose stand down".
----
----sd-phone reaches for the native ONLY when the surface may not keep the player moving (its
----client/phonecam.lua movementAllowed), which under stock config is never - so `cameraActive`
----alone would stand the pose down for a camera that replaced nothing, deleting the tablet out of
----the player's hands mid-shot. It exposes no export for which camera won, so this reads the
----mirrored movement keys configs/tablet.lua already documents as having to match sd-phone's.
+---Whether sd-phone framed the shot with the NATIVE cell-cam, which pins the ped and spawns its own
+---prop, rather than its scripted camera, which leaves the ped alone. Answers both "must keep-input
+---go off" and "must our pose stand down". sd-phone only reaches for the native when the surface may
+---not keep the player moving, and exposes no export for it - hence the mirrored movement keys.
 ---@return boolean
 local function nativeCellCam()
     if not cameraActive then return false end
     return cfg.AllowMovement == false or cfg.AllowMovementInCamera == false
 end
 
----Whether the pose applies right now. It stands down only for the native cell-cam, whose own pose
----and own phone prop ours would fight - the same deference, and the same condition, as sd-phone's
----pose module.
+---Whether the pose applies; it stands down only for the native cell-cam, whose own pose ours fights.
 ---@return boolean
 local function shouldHold()
     if not cfg.HoldAnimation then return false end
@@ -258,18 +225,32 @@ local function shouldHold()
     return tabletState.open
 end
 
----Creates a tablet prop, disables its collision, and rigidly welds it to a ped's hand bone. Local
----to this client: cross-player visibility spawns one of these per nearby holder, never a networked
----object, because a networked prop's ownership can migrate to a client whose sync then freezes it.
+---@type table<integer, true> Models known not to be available on this client.
+local unavailableModels = {}
+
+---Welds a collision-free tablet prop to a ped's hand bone. Always LOCAL: a networked prop's
+---ownership can migrate to a client whose sync then freezes it mid-hold.
 ---@param ped integer ped to attach the prop to
 ---@param color string colour to weld; must be a key of TABLET_COLORS
 ---@return integer|nil prop the welded prop entity, or nil if the model wouldn't stream
 local function createProp(ped, color)
     local model = joaat(cfg.PropPrefix .. color)
-    RequestModel(model)
-    local started = GetGameTimer()
-    while not HasModelLoaded(model) and GetGameTimer() - started < 1000 do Wait(0) end
-    if not HasModelLoaded(model) then return nil end
+    if unavailableModels[model] then return nil end
+
+    -- Answers the props-resource-not-started case outright, with no request and no waiting.
+    if not IsModelInCdimage(model) then
+        unavailableModels[model] = true
+        return nil
+    end
+
+    -- lib.requestModel errors rather than returning on timeout, hence the pcall. Releasing on the
+    -- failure path matters: this branch can run repeatedly and would leak a streaming reference.
+    if not pcall(lib.requestModel, model, 1000) then
+        SetModelAsNoLongerNeeded(model)
+        unavailableModels[model] = true
+        return nil
+    end
+
     local coords = GetEntityCoords(ped)
     local obj = CreateObject(model, coords.x, coords.y, coords.z, false, true, true)
     SetEntityCollision(obj, false, false)
@@ -287,34 +268,53 @@ local function removeProp()
     prop = nil
 end
 
----Broadcasts the hold state via the replicated `sdTablet` player statebag: the held colour while
----holding, false otherwise, so nearby clients weld a matching copy. No-op when cross-player
----visibility is off.
+---@type string|false|nil Last hold state handed to the server; nil until the first broadcast.
+local lastHoldSent = nil
+
 local function broadcastHoldState()
     if not cfg.PropVisibleToOthers then return end
-    LocalPlayer.state:set('sdTablet', shouldHold() and currentColor or false, true)
+    local desired = shouldHold() and currentColor or false
+    if desired == lastHoldSent then return end
+    lastHoldSent = desired
+    TriggerServerEvent('sd-tablet:server:setHolding', desired)
 end
 
----Plays the hold clip and welds the prop, on its own thread: the pose is cosmetic and must never
----gate the tablet opening.
+---@type boolean True while a playPose thread is between requesting the model and taking the handle.
+local propPending = false
+
+---Plays the hold clip and welds the prop on its own thread; the pose must never gate the open.
 local function playPose()
     CreateThread(function()
-        RequestAnimDict(cfg.AnimDict)
-        local started = GetGameTimer()
-        while not HasAnimDictLoaded(cfg.AnimDict) and GetGameTimer() - started < 1000 do Wait(0) end
-        -- The player may have closed the tablet, or the cell-cam taken the pose, during the load.
-        if not shouldHold() then return end
-        local ped = PlayerPedId()
+        local ped = cache.ped
         if not IsEntityPlayingAnim(ped, cfg.AnimDict, cfg.AnimName, 3) then
-            TaskPlayAnim(ped, cfg.AnimDict, cfg.AnimName, 8.0, -8.0, -1, POSE_FLAGS, 0.0, false, false, false)
+            -- lib.playAnim loads AND releases the dict; it errors when the clip never streams.
+            if not pcall(lib.playAnim, ped, cfg.AnimDict, cfg.AnimName, 8.0, -8.0, -1, POSE_FLAGS) then
+                return
+            end
         end
-        if not (prop and DoesEntityExist(prop)) then prop = createProp(ped, currentColor) end
+        -- That load yields, so the player may have closed the tablet or the cell-cam taken over.
+        if not shouldHold() then
+            StopAnimTask(ped, cfg.AnimDict, cfg.AnimName, 1.0)
+            return
+        end
+        if prop and DoesEntityExist(prop) then return end
+        if propPending then return end
+        propPending = true
+        -- Re-read rather than reuse `ped`: cache.ped is current across the yield above.
+        local obj = createProp(cache.ped, currentColor)
+        propPending = false
+        if not obj then return end
+        if not shouldHold() or (prop and DoesEntityExist(prop)) then
+            DeleteObject(obj)
+            return
+        end
+        prop = obj
     end)
 end
 
 ---Stops our clip and removes the prop.
 local function stopPose()
-    local ped = PlayerPedId()
+    local ped = cache.ped
     if IsEntityPlayingAnim(ped, cfg.AnimDict, cfg.AnimName, 3) then
         StopAnimTask(ped, cfg.AnimDict, cfg.AnimName, 1.0)
     end
@@ -327,22 +327,25 @@ local function updatePose()
     broadcastHoldState()
 end
 
--- Re-applies the held clip on a 500ms poll if the game clears it. Movement is what clears it: an
--- upper-body secondary task loses to sprints, jumps and vehicle transitions, and this device is
--- explicitly usable while walking.
+-- Re-applies the held clip if the game clears it: an upper-body secondary task loses to sprints,
+-- jumps and vehicle transitions, and this device is explicitly usable while walking. Backs off to
+-- a 1s tick while stowed, since the thread lives for the whole session either way.
 CreateThread(function()
     while true do
-        if shouldHold() and not IsEntityPlayingAnim(PlayerPedId(), cfg.AnimDict, cfg.AnimName, 3) then
-            playPose()
+        if not tabletState.open then
+            Wait(1000)
+        else
+            if shouldHold() and not IsEntityPlayingAnim(cache.ped, cfg.AnimDict, cfg.AnimName, 3) then
+                playPose()
+            end
+            Wait(500)
         end
-        Wait(500)
     end
 end)
 
--- Keeps the tablet out of the player's own rear shot. sd-phone hides the holder for exactly this
--- reason and hides ITS prop on the next line (client/pose.lua), because hiding a ped does not hide
--- what is attached to it - and our prop is a separate entity, spawned by a separate resource, so
--- its hide never covers ours. Locally invisible lasts one frame, hence the per-frame re-assert.
+-- Keeps the tablet out of the player's own rear shot. Hiding a ped does not hide what is attached
+-- to it, and our prop is a separate resource's entity, so sd-phone's own hide never covers it.
+-- SetEntityLocallyInvisible lasts one frame, hence the per-frame re-assert.
 CreateThread(function()
     while true do
         if cameraActive and cameraRearLens and prop and DoesEntityExist(prop) then
@@ -360,74 +363,90 @@ end)
 ---AllowMovement on.
 local function syncKeepInput()
     if tabletState.open and cfg.AllowMovement then
-        -- The native cell-cam pins the ped at engine level whatever keep-input says, so keeping it
-        -- on there would only leak the movement keys into the game underneath a frozen player.
+        -- The native cell-cam pins the ped anyway, so keep-input there only leaks movement keys.
         SetNuiFocusKeepInput((not typingInTablet or typingNumeric) and not nativeCellCam())
     end
 end
 
----@type boolean True while the movement-suppression thread is running.
-local movementThreadRunning = false
+---@type boolean True while the per-frame input thread is running.
+local inputThreadRunning = false
 
----Runs one thread per open that suppresses combat, mouse-look, weapon-wheel and chat controls
----each frame, and closes the tablet when the pause menu activates. Mirrors sd-phone's, because
----the two devices share a UI and must not feel different to hold.
-local function startMovementThread()
-    if not cfg.AllowMovement or movementThreadRunning then return end
-    movementThreadRunning = true
+---Runs ONE per-frame thread per open: holds the pause control down unconditionally, and with
+---AllowMovement on also suppresses combat, mouse-look, weapon-wheel and chat as sd-phone does.
+local function startInputThread()
+    if inputThreadRunning then return end
+    inputThreadRunning = true
     CreateThread(function()
-        while tabletState.open do
-            if IsPauseMenuActive() then
-                CloseTablet()
-            elseif (not typingInTablet or typingNumeric) and not nativeCellCam() then
-                DisablePlayerFiring(PlayerId(), true)
-                -- The Camera app's Alt toggle hands the mouse to the game to aim the lens, so
-                -- leave mouse-look alone while it has: suppressing it makes the lens immovable.
-                if not lookMode and not cameraCursorFree then
-                    DisableControlAction(0, 1, true)
-                    DisableControlAction(0, 2, true)
-                end
-                DisableControlAction(0, 24, true)
-                DisableControlAction(0, 25, true)
-                DisableControlAction(0, 257, true)
-                DisableControlAction(0, 263, true)
-                DisableControlAction(0, 264, true)
-                DisableControlAction(0, 140, true)
-                DisableControlAction(0, 141, true)
-                DisableControlAction(0, 142, true)
-                DisableControlAction(0, 143, true)
-                DisableControlAction(0, 37, true)
-                DisableControlAction(0, 106, true)
-                DisableControlAction(0, 245, true)
-                DisableControlAction(0, 246, true)
-                -- Scroll-wheel fall-throughs under keep-input: the UI owns the wheel, so vehicle
-                -- radio cycling, the radio wheel and weapon cycling must not react.
-                DisableControlAction(0, 14, true)
-                DisableControlAction(0, 15, true)
-                DisableControlAction(0, 16, true)
-                DisableControlAction(0, 17, true)
-                DisableControlAction(0, 81, true)
-                DisableControlAction(0, 82, true)
-                DisableControlAction(0, 83, true)
-                DisableControlAction(0, 84, true)
-                DisableControlAction(0, 85, true)
-                DisableControlAction(0, 99, true)
-                DisableControlAction(0, 100, true)
-                if typingNumeric then
-                    -- Digit pad up: the number row must not fire GTA weapon-slot binds.
-                    for control = 157, 166 do
-                        DisableControlAction(0, control, true)
+        -- Outer loop so a reopen DURING the trailing hold below rejoins instead of dying with the
+        -- flag about to clear, which would leave an open tablet suppressing nothing.
+        while true do
+            while tabletState.open do
+                DisableControlAction(0, 199, true) -- INPUT_FRONTEND_PAUSE
+                DisableControlAction(0, 200, true) -- INPUT_FRONTEND_PAUSE_ALTERNATE
+
+                if cfg.AllowMovement then
+                    if IsPauseMenuActive() then
+                        CloseTablet()
+                    elseif (not typingInTablet or typingNumeric) and not nativeCellCam() then
+                        DisablePlayerFiring(cache.playerId, true)
+                        -- The Camera app's Alt toggle aims the lens with the mouse; suppressing
+                        -- mouse-look while it has would make the lens immovable.
+                        if not lookMode and not cameraCursorFree then
+                            DisableControlAction(0, 1, true)
+                            DisableControlAction(0, 2, true)
+                        end
+                        DisableControlAction(0, 24, true)
+                        DisableControlAction(0, 25, true)
+                        DisableControlAction(0, 257, true)
+                        DisableControlAction(0, 263, true)
+                        DisableControlAction(0, 264, true)
+                        DisableControlAction(0, 140, true)
+                        DisableControlAction(0, 141, true)
+                        DisableControlAction(0, 142, true)
+                        DisableControlAction(0, 143, true)
+                        DisableControlAction(0, 37, true)
+                        DisableControlAction(0, 106, true)
+                        DisableControlAction(0, 245, true)
+                        DisableControlAction(0, 246, true)
+                        -- Scroll-wheel fall-throughs under keep-input: the UI owns the wheel.
+                        DisableControlAction(0, 14, true)
+                        DisableControlAction(0, 15, true)
+                        DisableControlAction(0, 16, true)
+                        DisableControlAction(0, 17, true)
+                        DisableControlAction(0, 81, true)
+                        DisableControlAction(0, 82, true)
+                        DisableControlAction(0, 83, true)
+                        DisableControlAction(0, 84, true)
+                        DisableControlAction(0, 85, true)
+                        DisableControlAction(0, 99, true)
+                        DisableControlAction(0, 100, true)
+                        if typingNumeric then
+                            -- Digit pad up: the number row must not fire GTA weapon-slot binds.
+                            for control = 157, 166 do
+                                DisableControlAction(0, control, true)
+                            end
+                        end
                     end
                 end
+                Wait(0)
             end
-            Wait(0)
+
+            -- Held a few frames past the close, or the closing keypress opens the escape menu.
+            local held = 0
+            while held < 15 and not tabletState.open do
+                DisableControlAction(0, 199, true)
+                DisableControlAction(0, 200, true)
+                held = held + 1
+                Wait(0)
+            end
+            if not tabletState.open then break end
         end
-        movementThreadRunning = false
+        -- No yield since the break, so an open cannot be refused by a flag about to clear.
+        inputThreadRunning = false
     end)
 end
 
----Enters look mode: releases the NUI cursor so the mouse rotates the camera while the tablet
----stays on screen. This is how a walking player aims the lens in the forwarded Camera app -
+---Releases the NUI cursor so the mouse rotates the camera with the tablet still on screen;
 ---sd-phone's own look keybind only answers while the PHONE is open, so this device needs its own.
 local function enterLookMode()
     if lookMode or not tabletState.open or not cfg.AllowMovement then return end
@@ -440,16 +459,14 @@ end
 local function exitLookMode()
     if not lookMode then return end
     lookMode = false
-    -- Never grab the cursor back while the Camera app has deliberately released it, or its own
-    -- cursorOn flag desyncs and the viewfinder's key relays go dead.
+    -- Never grab the cursor back while the Camera app has released it, or its cursorOn desyncs.
     if tabletState.open and not cameraCursorFree then
         SetNuiFocus(true, true)
         syncKeepInput()
     end
 end
 
--- sd-phone announces the cell-cam's state as plain client events, so the tablet hears them
--- without any wiring on the other side: the Camera app it drives is OUR screen's.
+-- sd-phone announces cell-cam state as plain client events, so we hear them with no wiring there.
 ---@param on any truthy while the cell-cam view is live
 AddEventHandler('sd-phone:client:cameraMode', function(on)
     if not tabletState.open then return end
@@ -471,9 +488,8 @@ end)
 
 -------------------------------------------------------------------- open / close
 
----Builds the tablet's sd-phone:open payload. Same shape as sd-phone's OpenPhone, from the tablet's
----own config, with the phone app absent from both the dock and the catalog and the SIM block
----always disabled - a tablet has no tray, and SIM mode refuses to open one at all.
+---Builds the sd-phone:open payload: OpenPhone's shape from the tablet's own config, with the phone
+---app absent from the dock and catalog.
 ---@return table
 local function openPayload()
     local apps, dock = visibleApps()
@@ -503,21 +519,10 @@ local function openPayload()
 end
 
 ---Fetches the acting character's installed apps + home layout and pushes them into the open NUI.
----
----Routed through the seam rather than straight to sd-phone's server callback on purpose: sd-phone
----resolves WHOSE apps these are from the acting identity, and going through its own NUI handler
----means the tablet can never resolve that differently from the phone. This is the payload that
----makes the two devices the same device - an app installed on the phone is on the tablet the next
----time it opens, because there is only one installed list.
----
----The installed list is genuinely shared; the home LAYOUT is not, because a layout only means
----anything against the grid it was arranged on - 36 icons to a page here against the phone's 24.
----So one stored column holds an envelope, { devices = { phone = '...', tablet = '...' } }, written
----per device by sd-phone's server (server/apps/actions.lua) off the `device` the UI sends with
----each save, and unwrapped by the SHARED bundle, which knows its own id (web/src/apps/appstore/
----appsApi.ts, parseLayout). Neither end of that is ours to second-guess: the layout goes through
----this push exactly as the server stored it, envelope and all, and our copy of the bundle takes
----the tablet slice out of it. Slicing or namespacing anything here would break both devices.
+---Routed through the seam so the tablet can never resolve WHOSE apps these are differently from
+---the phone. The installed list is genuinely shared; the home LAYOUT is not (36 icons to a page
+---here against the phone's 24), so it travels as a per-device envelope that the SHARED bundle
+---unwraps by its own id. The layout is pushed exactly as stored - slicing it here breaks both.
 local function pushInstalledApps()
     bridge.invoke('sd-phone:apps:list', {}, function(res)
         if not tabletState.open then return end
@@ -532,9 +537,8 @@ local function pushInstalledApps()
     end)
 end
 
----Pulls one weather + world-time snapshot and pushes it in. sd-phone's 5s poll already covers a
----companion device, but waiting up to five seconds for the Weather app to paint on open is a
----visible stall, so the first snapshot is asked for directly.
+---Pulls one weather snapshot directly; sd-phone's 5s poll covers us after, but waiting that long
+---for the Weather app to paint on open is a visible stall.
 local function pushWeather()
     bridge.invoke('sd-phone:weather:get', {}, function(res)
         if not tabletState.open or type(res) ~= 'table' then return end
@@ -542,68 +546,70 @@ local function pushWeather()
     end)
 end
 
----Opens the tablet NUI, arms the mirror, and takes the screen from the phone if it had it.
----Refuses while dead, swimming, driving, disabled, or in SIM mode.
----@return boolean opened
-local function OpenTablet()
+---Whether the tablet may go on screen. Every condition is re-readable: the open path checks them
+---again after the payload round-trip, which is long enough to die, dive in or take a wheel.
+---@return boolean ok
+---@return string|nil message reason to show when refused
+local function canOpen()
     if tabletState.open then return false end
 
     if GetResourceState(PHONE) ~= 'started' then
-        notify('The tablet can\'t connect right now.', 'error')
-        return false
+        return false, 'The tablet can\'t connect right now.'
     end
 
-    -- One switch disables both devices: a script that takes the player's phone away (a scene, a
-    -- cell, a cutscene) means them to have no screen at all, not a spare one.
+    -- One switch disables both devices: a script taking the phone away means no screen, not a spare.
     local gotDisabled, disabled = phoneExport('isDisabled')
     if gotDisabled and disabled == true then
-        notify('You can\'t use your tablet right now.', 'error')
+        return false, 'You can\'t use your tablet right now.'
+    end
+
+    -- No SIM check: the tablet borrows the identity of the SIM in the phone you carry, exactly as
+    -- it borrows everything else, so a request already answers as the right number. With no SIM
+    -- the shared UI shows its own No Service screen, the same as the phone does.
+    if cfg.BlockWhileDead and IsEntityDead(cache.ped) then
+        return false, 'You can\'t use your tablet right now.'
+    end
+    if cfg.BlockWhileSwimming and IsPedSwimming(cache.ped) then
+        return false, 'You can\'t use your tablet while swimming.'
+    end
+    -- cache.vehicle is false on foot; seat -1 is the driver's.
+    if cfg.BlockWhileDriving and cache.vehicle and cache.seat == -1 then
+        return false, 'Not while you\'re driving.'
+    end
+
+    return true
+end
+
+---Opens the tablet NUI, arms the mirror, and takes the screen from the phone if it had it.
+---Refuses while dead, swimming, driving, or disabled.
+---@return boolean opened
+local function OpenTablet()
+    local ok, message = canOpen()
+    if not ok then
+        if message then notify(message, 'error') end
         return false
     end
 
-    -- SIM servers used to refuse outright, which left the tablet unusable on every one of them.
-    -- It has no SIM of its own and never will: it borrows the identity of the SIM in the phone
-    -- you are carrying, exactly as it borrows everything else. sd-phone resolves that per PLAYER,
-    -- so a tablet request already answers as the right number. With no SIM the shared UI shows
-    -- its own No Service screen, the same as the phone does.
+    -- Built BEFORE anything is committed: openPayload yields on a server round-trip, and taking
+    -- focus or arming the mirror first would leave the player behind a cursor with nothing on
+    -- screen for its duration. The lock flag is stamped first because the payload carries it.
+    tabletState.locked = cfg.StartLocked ~= false
+    local payload = openPayload()
 
-    local ped = PlayerPedId()
-    if cfg.BlockWhileDead and IsEntityDead(ped) then
-        notify('You can\'t use your tablet right now.', 'error')
-        return false
-    end
-    if cfg.BlockWhileSwimming and IsPedSwimming(ped) then
-        notify('You can\'t use your tablet while swimming.', 'error')
-        return false
-    end
-    if cfg.BlockWhileDriving and IsPedInAnyVehicle(ped, false)
-        and GetPedInVehicleSeat(GetVehiclePedIsIn(ped, false), -1) == ped then
-        notify('Not while you\'re driving.', 'error')
+    -- Re-run across that yield: the player can die, dive in or take a wheel while the server answers.
+    local stillOk, lateMessage = canOpen()
+    if not stillOk then
+        if lateMessage then notify(lateMessage, 'error') end
         return false
     end
 
-    -- One device at a time: the phone gives up the screen here, so focus, the cell-cam and
-    -- pma-voice only ever have one owner. sd-phone does the mirror image of this in OpenPhone.
+    -- One device at a time, so focus, the cell-cam and pma-voice only ever have one owner.
     exports[PHONE]:close()
 
-    tabletState.open   = true
-    tabletState.locked = cfg.StartLocked ~= false
+    tabletState.open = true
 
     mirror.arm(true)
     mirror.setCompanionOpen(true)
-
-    CreateThread(function()
-        while tabletState.open do
-            DisableControlAction(0, 199, true) -- INPUT_FRONTEND_PAUSE
-            DisableControlAction(0, 200, true) -- INPUT_FRONTEND_PAUSE_ALTERNATE
-            Wait(0)
-        end
-        for _ = 1, 15 do
-            DisableControlAction(0, 199, true)
-            DisableControlAction(0, 200, true)
-            Wait(0)
-        end
-    end)
 
     updatePose()
 
@@ -612,25 +618,20 @@ local function OpenTablet()
         typingInTablet = false
         typingNumeric  = false
         SetNuiFocusKeepInput(true)
-        startMovementThread()
     end
+    startInputThread()
 
-    SendNUIMessage({ action = 'sd-phone:open', data = openPayload() })
+    SendNUIMessage({ action = 'sd-phone:open', data = payload })
     SendNUIMessage({ action = 'sd-phone:session', data = { startMs = SESSION_START_MS } })
 
-    -- "A device of ours is on screen." sd-phone's own modules key several live feeds off this
-    -- event, and every one of them is about the player rather than the handset: the cell-service
-    -- and Wi-Fi scans only tick while a device is up, Health only pushes vitals while one is up,
-    -- and - decisively - the Camera app restores NUI focus on exit ONLY if it believes a device is
-    -- watching. Without this, leaving the viewfinder on the tablet strands the player with no
-    -- cursor. The event is local, so announcing it is the supported way to say so.
+    -- "A device of ours is on screen": sd-phone keys its cell-service, Wi-Fi and Health feeds off
+    -- this, and the Camera app restores NUI focus on exit ONLY if it believes a device is watching.
     TriggerEvent('sd-phone:client:openState', true)
 
     -- AirShare presence: players appear in each other's share sheets while a device is out.
     TriggerServerEvent('sd-phone:server:phone:setOpen', true)
 
-    -- Both need a round-trip, and the tablet is already on screen behind the lockscreen, so they
-    -- land as follow-ups rather than gating the reveal.
+    -- Both need a round-trip and the lockscreen is already up, so they follow rather than gate it.
     pushWeather()
     pushInstalledApps()
 
@@ -650,9 +651,7 @@ function CloseTablet()
     cameraRearLens   = false
     cameraCursorFree = false
 
-    -- Stand the seam down first. Leaving either flag set makes sd-phone keep firing a client
-    -- event for every push it makes, keep pumping its weather poll, and keep handing us focus
-    -- calls meant for a screen that is no longer there.
+    -- Seam down first, or sd-phone keeps mirroring pushes and focus at a screen that is gone.
     mirror.setCompanionOpen(false)
     mirror.arm(false)
 
@@ -667,52 +666,33 @@ function CloseTablet()
     debugPrint('tablet closed')
 end
 
--- sd-phone opening its own phone tells every companion to stand down (client/main.lua fires this
--- at the top of OpenPhone, before it takes focus). This is the other half of the exclusion the
--- open path above starts.
+-- sd-phone fires this at the top of OpenPhone: the other half of the exclusion our open starts.
 AddEventHandler('sd-phone:client:companion:close', function()
     CloseTablet()
 end)
 
----The admin panel is a second surface inside sd-phone's OWN frame, and it opens by taking NUI
----focus for itself (its client/admin.lua) before pushing itself in. Neither half survives a
----companion holding the screen: the focus call is re-routed to us by the seam, and the push is
----dropped here because this device's build has no panel to receive it - so the panel would render
----in a frame nobody is looking at while the cursor sat on ours, and nothing would be clickable
----until the tablet was closed. So give the screen up for it exactly as we do for the phone.
----
----Both cross-resource orderings land correctly, because CloseTablet clears the companion flag
----BEFORE it announces sd-phone:client:openState(false):
----  * sd-phone first - it takes focus (routed to a tablet that is about to close) and pushes the
----    panel (dropped at our mirror); our close then fires openState(false), and sd-phone's admin
----    handler re-asserts focus on that event with the seam already down, so it lands on its frame.
----  * us first - the seam is down before sd-phone's handler runs, so its focus call is never
----    routed anywhere and lands on its own frame directly.
----Either way the panel and the cursor end up in the same frame.
+---The admin panel is a surface inside sd-phone's OWN frame, and neither its focus call (re-routed
+---to us by the seam) nor its push (dropped here, we have no panel) survives a companion holding
+---the screen - so give the screen up for it exactly as we do for the phone. Either cross-resource
+---ordering lands, because CloseTablet clears the companion flag before announcing openState(false).
 RegisterNetEvent('sd-phone:client:admin:open', function()
     CloseTablet()
 end)
 
--- Teardown of the SHARED profile. Both of these are pushed by sd-phone into its own frame, and
--- both fire at moments when neither device need be on screen - which is exactly when the mirror is
--- disarmed, so neither would ever reach us. Our NUI is loaded from resource start and keeps
--- running hidden, so a missed teardown leaves it to reopen on the previous profile's cached data.
--- Registering the two net events ourselves is the only delivery that does not depend on being
--- visible; the matching pushes are dropped at the mirror (client/policy.lua), which is what stops
--- an OPEN tablet handling each of them twice.
+-- Teardown of the SHARED profile. Both fire when neither device need be on screen, i.e. exactly
+-- when the mirror is disarmed - and our hidden NUI would then reopen on stale data. Registering
+-- the net events ourselves is the only delivery that does not depend on being visible; the
+-- matching pushes are dropped at the mirror so an OPEN tablet never handles them twice.
 
----A cloud-backup restore replaced the acting profile's data in place: the NUI drops every cached
----trace (kept-alive apps, hydrated settings, data stores) and rehydrates. The installed-apps
----follow-up re-runs with it, since a restore changes both the installed list and the home layout.
+---A cloud-backup restore replaced the profile's data in place: drop every cached trace and
+---rehydrate. Installed apps re-run with it, since a restore changes the list and the layout.
 RegisterNetEvent('sd-phone:client:profileReset', function()
     SendNUIMessage({ action = 'sd-phone:profileReset' })
     if tabletState.open then pushInstalledApps() end
 end)
 
----An admin wipe tells the React app to clear its local storage and RELOAD, which tears our UI down
----to an empty page. A device left flagged open behind an empty page holds focus with nothing on
----screen to release it and refuses to reopen, so it stands down first - and the focus drop trails
----the push for the same reason sd-phone's does: the reloaded frame must not inherit one.
+---An admin wipe reloads the React app to an empty page; a device left flagged open behind it holds
+---focus with nothing to release it, so it stands down first and the focus drop trails the push.
 RegisterNetEvent('sd-phone:client:wipe', function()
     CloseTablet()
     SendNUIMessage({ action = 'sd-phone:wipe' })
@@ -721,15 +701,15 @@ end)
 
 -------------------------------------------------------------------- entry points
 
----Keybind toggle: closes when open, otherwise asks the server whether this player may open one.
----Ownership is server-authoritative for the same reason sd-phone's is - the item check is the
----only thing standing between a keybind and a free tablet.
+---Keybind toggle; ownership is server-authoritative because the item check is the only thing
+---standing between a keybind and a free tablet.
 local function ToggleTablet()
     if tabletState.open then CloseTablet() return end
 
-    -- The last-used colour rides along as a hint so the keybind keeps handing back the same
-    -- tablet; the server only honours it while that item is still owned.
-    local res = lib.callback.await('sd-tablet:server:resolveOpen', false, currentColor)
+    -- The last-used colour is a hint the server only honours while that item is still owned. The
+    -- await is bounded because an unbounded one never returns if our server is mid-restart, and a
+    -- timeout resolves to nil - which the type check below already reports as a refusal.
+    local res = lib.callback.await('sd-tablet:server:resolveOpen', 10000, currentColor)
     if type(res) ~= 'table' or res.ok ~= true then
         notify((type(res) == 'table' and res.message) or 'You don\'t have a tablet.', 'error')
         return
@@ -738,19 +718,24 @@ local function ToggleTablet()
     OpenTablet()
 end
 
--- Keybind wiring; the `-` command is the no-op release half of the +command mapping.
-RegisterCommand('+sdtablet_toggle', ToggleTablet, false)
-RegisterCommand('-sdtablet_toggle', function() end, false)
-RegisterKeyMapping('+sdtablet_toggle', 'Toggle Tablet', 'keyboard', cfg.Keybind)
+lib.addKeybind({
+    name        = 'sdtablet_toggle',
+    description = 'Toggle Tablet',
+    defaultKey  = cfg.Keybind,
+    onPressed   = ToggleTablet,
+})
 
--- Hold-to-look: the +command frees the mouse for camera rotation, the -command restores the cursor.
-RegisterCommand('+sdtablet_look', enterLookMode, false)
-RegisterCommand('-sdtablet_look', exitLookMode, false)
-RegisterKeyMapping('+sdtablet_look', 'Tablet: Hold to look around', 'keyboard', cfg.LookKeybind)
+-- Hold-to-look: press frees the mouse for camera rotation, release restores the cursor.
+lib.addKeybind({
+    name        = 'sdtablet_look',
+    description = 'Tablet: Hold to look around',
+    defaultKey  = cfg.LookKeybind,
+    onPressed   = enterLookMode,
+    onReleased  = exitLookMode,
+})
 
----Opens the tablet after a tablet item is used, in that item's colour. The server has already
----resolved ownership by definition - it is the item's own use callback that fired this. The colour
----is whitelist-checked because it arrives over the network.
+---Opens after an item is used, in its colour; ownership is proven by the use callback firing at
+---all, and the colour is whitelist-checked because it arrives over the network.
 ---@param color string|nil colour of the item that was used
 RegisterNetEvent('sd-tablet:client:openFromItem', function(color)
     if color and TABLET_COLORS[color] then currentColor = color end
@@ -759,10 +744,8 @@ end)
 
 -------------------------------------------------------------------- device-local NUI handlers
 
--- Every one of these is an action the shared UI performs on the DEVICE it is running on. Each has
--- a counterpart in sd-phone/client/main.lua that does the same job for the phone; forwarding any
--- of them would run the phone's version against a frame nobody is looking at. client/policy.lua
--- lists them and client/rpc.lua refuses to bind unless all of them exist.
+-- Actions the shared UI performs on the DEVICE it runs on; forwarding any would run sd-phone's
+-- counterpart against a frame nobody is looking at. rpc.lua refuses to bind unless all exist.
 ---@type table<string, fun(payload: any, cb: fun(result: any))>
 local LOCAL_HANDLERS = {
     ---React to Lua: the NUI requests the device be closed (swipe down / back gesture).
@@ -771,7 +754,8 @@ local LOCAL_HANDLERS = {
         cb({ ok = true })
     end,
 
-    ---React to Lua: unlock gesture finished. Clears the locked flag; it re-arms on the next open.
+    ---React to Lua: unlock gesture finished; re-arms on the next open. No passcode check belongs
+    ---here - the React app compares it, and the lockscreen is privacy, not a security boundary.
     ['sd-phone:unlock'] = function(_, cb)
         tabletState.locked = false
         cb({ ok = true })
@@ -783,9 +767,8 @@ local LOCAL_HANDLERS = {
         cb({ ok = true })
     end,
 
-    ---React to Lua: a text field gained or lost focus. Full typing releases keep-input so keys
-    ---reach only the field; numeric typing (PIN pads) keeps it so the player can still move, with
-    ---the digit weapon binds suppressed by the movement thread instead.
+    ---React to Lua: a text field gained or lost focus. Full typing releases keep-input; numeric
+    ---typing keeps it, with the digit weapon binds suppressed by the input thread instead.
     ---@param data table|nil { typing: boolean, numeric: boolean }
     ['sd-phone:typing'] = function(data, cb)
         typingInTablet = data and data.typing and true or false
@@ -801,9 +784,8 @@ local LOCAL_HANDLERS = {
         cb({ ok = true })
     end,
 
-    ---React to Lua: lockscreen torch button. A tablet has no torch, so the beam is always off -
-    ---answered rather than denied, because the lockscreen asks unprompted and a refusal would
-    ---surface as an error toast for a button the player never pressed.
+    ---React to Lua: lockscreen torch. A tablet has none, so it is answered rather than denied -
+    ---the lockscreen asks unprompted, and a refusal would toast for a button nobody pressed.
     ['sd-phone:flashlight:toggle'] = function(_, cb)
         cb({ on = false })
     end,
@@ -819,12 +801,8 @@ if config.Debug then
     rpc.setTrace(function(kind, action) debugPrint(kind, action) end)
 end
 
--- Which lens the forwarded Camera app is framing with. sd-phone announces the viewfinder opening
--- and closing as client events, but the FLIP only ever travels page -> Lua as this callback, so
--- watching it on its way through is the one place this side can learn the lens. The app always
--- enters on the rear one (its enterCameraView resets frontCam), and both ways to flip - the
--- on-screen button and the Up-arrow that sd-phone relays into the page - end here, so there is no
--- second path to miss.
+-- The FLIP only ever travels page -> Lua as this callback, so watching it through is the one place
+-- this side can learn the lens. The app always enters on the rear one, and both ways to flip end here.
 rpc.watch('sd-phone:camera:open',  function() cameraRearLens = true  end)
 rpc.watch('sd-phone:camera:close', function() cameraRearLens = false end)
 rpc.watch('sd-phone:camera:selfie', function(payload)
@@ -838,8 +816,7 @@ mirror.bind({
 
 -------------------------------------------------------------------- background
 
--- Cosmetic battery drain: one percent every 30s while the tablet is open, pushed to the React app.
--- The tablet's own charge, which is why the phone's battery push is dropped at the mirror.
+-- Cosmetic drain, 1% per 30s while open; the tablet's OWN charge, so the phone's push is dropped.
 CreateThread(function()
     while true do
         Wait(30000)
@@ -850,9 +827,20 @@ CreateThread(function()
     end
 end)
 
----@type table<integer, { obj: integer, color: string }> Server id -> local tablet-prop copy welded
----onto that remote holder's ped, with the colour it was welded in.
+---@type table<integer, { obj: integer, color: string }> Server id -> welded local copy + its colour.
 local remoteProps = {}
+
+---@type table<integer, integer> Server id -> game time of the last rebuild accepted for that holder.
+local remoteLastBuild = {}
+
+---@type table<integer, true> Holders mid-spawn; createProp yields, so two changes would orphan one.
+local remoteBuilding = {}
+
+---@type integer Minimum ms between rebuilds for one holder. A rebuild is a delete plus a spawn on
+---EVERY observer, so the receiving side bounds it rather than trusting the sender's rate - the
+---case this exists for is a client alternating two valid colours, which never repeats a value and
+---so slips straight past the "already welded in this colour" check below.
+local REMOTE_REBUILD_MIN <const> = 500
 
 ---Deletes a remote holder's welded prop copy, if any. Idempotent.
 ---@param source integer server id of the remote holder
@@ -862,11 +850,10 @@ local function removeRemoteProp(source)
     remoteProps[source] = nil
 end
 
--- Cross-player prop visibility: the holder broadcasts the replicated `sdTablet` player statebag
--- and every client welds its own local prop copy onto the holder's ped.
+-- Cross-player visibility: the server ownership-checks the colour and writes the replicated
+-- `sdTablet` bag, and every client welds its own local copy onto the holder's ped off it.
 if cfg.PropVisibleToOthers then
-    ---Resolves a `player:<serverId>` bag to (serverId, ped); ped is 0 when that player isn't in
-    ---scope on this client.
+    ---Resolves a `player:<serverId>` bag to (serverId, ped); ped is 0 when out of scope here.
     ---@param bagName string
     ---@return integer? source, integer ped
     local function bagOwner(bagName)
@@ -879,42 +866,61 @@ if cfg.PropVisibleToOthers then
 
     AddStateBagChangeHandler('sdTablet', nil, function(bagName, _key, value)
         local source, ped = bagOwner(bagName)
-        if not source or source == GetPlayerServerId(PlayerId()) then return end
+        if not source or source == cache.serverId then return end
+        -- Stowing is never throttled: it only deletes, and refusing it would strand a prop.
         if not value or ped == 0 then
             removeRemoteProp(source)
             return
         end
         -- The bag carries the holder's colour, so an unknown one is dropped rather than welded.
         if not TABLET_COLORS[value] then return end
+
         local entry = remoteProps[source]
         if entry and entry.color == value and DoesEntityExist(entry.obj) then return end
+
+        -- Everything past here spawns an entity, so it is rate-limited and single-flighted.
+        if remoteBuilding[source] then return end
+        local now = GetGameTimer()
+        local last = remoteLastBuild[source]
+        if last and now - last < REMOTE_REBUILD_MIN then return end
+        remoteLastBuild[source] = now
+
+        remoteBuilding[source] = true
         removeRemoteProp(source)
         local obj = createProp(ped, value)
+        remoteBuilding[source] = nil
         if obj then remoteProps[source] = { obj = obj, color = value } end
     end)
 
-    -- 1s sweep: removes copies whose owner left scope or whose prop no longer exists.
+    -- 1s sweep for copies whose owner left scope, idling at 2s while nothing is welded.
     CreateThread(function()
         while true do
-            Wait(1000)
-            for source, entry in pairs(remoteProps) do
-                local plyr = GetPlayerFromServerId(source)
-                local ped = plyr ~= -1 and GetPlayerPed(plyr) or 0
-                if ped == 0 or not DoesEntityExist(ped) or not DoesEntityExist(entry.obj) then
-                    removeRemoteProp(source)
+            if not next(remoteProps) and not next(remoteLastBuild) then
+                Wait(2000)
+            else
+                Wait(1000)
+                for source, entry in pairs(remoteProps) do
+                    local plyr = GetPlayerFromServerId(source)
+                    local ped = plyr ~= -1 and GetPlayerPed(plyr) or 0
+                    if ped == 0 or not DoesEntityExist(ped) or not DoesEntityExist(entry.obj) then
+                        removeRemoteProp(source)
+                    end
+                end
+                -- Stamps outlive their prop by design - clearing one on stow would let a client
+                -- alternating hold/stow past the throttle - so they retire when the player leaves.
+                for source in pairs(remoteLastBuild) do
+                    if not remoteProps[source] and GetPlayerFromServerId(source) == -1 then
+                        remoteLastBuild[source] = nil
+                    end
                 end
             end
         end
     end)
 end
 
----Re-stamps the session anchor and tells the NUI the character resolved, mirroring sd-phone's own
----handling: settings only resolve once the citizenid exists, so the UI re-pulls its per-player
----state the moment the framework reports the player in. Both devices stamp from the same events,
----which is why the Health app's "time awake" agrees across them.
----Pushed even while the tablet is closed, for the same reason sd-phone pushes it while the phone
----is: the NUI is loaded from resource start and keeps running hidden, so a skipped signal leaves
----it to reopen on the previous character's settings.
+---Re-stamps the session anchor and tells the NUI the character resolved: settings only resolve
+---once the citizenid exists. Pushed even while closed, because the hidden NUI would otherwise
+---reopen on the previous character's settings.
 local function pushCharacterLoaded()
     SESSION_START_MS = GetCloudTimeAsInt() * 1000
     SendNUIMessage({ action = 'sd-phone:client:characterLoaded' })
@@ -923,13 +929,10 @@ end
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', pushCharacterLoaded)
 RegisterNetEvent('esx:playerLoaded', pushCharacterLoaded)
 
----sd-phone's server fires this when settings appear after the UI has already hydrated (its
----lb-phone import writes phone_settings partway through boot). The tablet's copy of that UI needs
----the same nudge; net events reach every resource that registered them.
+---sd-phone fires this when settings appear after the UI has hydrated; our copy needs the nudge too.
 RegisterNetEvent('sd-phone:client:rehydrate', pushCharacterLoaded)
 
----Resource restart with the character already in: the framework load events above won't re-fire,
----but the freshly reloaded NUI still needs the character signal.
+---Restart with the character already in: the load events won't re-fire, but the NUI still needs it.
 AddEventHandler('onClientResourceStart', function(resource)
     if resource ~= GetCurrentResourceName() then return end
     SetTimeout(5000, pushCharacterLoaded)
@@ -945,17 +948,17 @@ exports('isOpen', function() return tabletState.open end)
 ---@return boolean
 exports('isLocked', function() return tabletState.locked end)
 
----exports['sd-tablet']:open() - no ownership check; the caller is another script that has already
----decided this player may have a tablet on screen.
+---exports['sd-tablet']:open() - no ownership check; the caller has already decided.
+---CALL THIS FROM A THREAD: it yields on a server round-trip, so a call from a resource's top level
+---or a native callback raises rather than returns. CreateThread around it is always safe.
 ---@return boolean opened
 exports('open', OpenTablet)
 
 ---exports['sd-tablet']:close()
 exports('close', function() CloseTablet() end)
 
----Launches an app on the tablet - exports['sd-tablet']:openApp(appId, link). The tablet's own
----counterpart to exports['sd-phone']:openApp, which targets the phone (and opens it, which closes
----this device). Returns false on a refused open or malformed arguments.
+---Launches an app - exports['sd-tablet']:openApp(appId, link); the counterpart to sd-phone's, which
+---targets the phone. Yields when the tablet is closed, so call it from a thread.
 ---@param appId string app id as the home screen knows it (e.g. 'messages')
 ---@param link table|nil optional deep-link payload
 ---@return boolean accepted
@@ -972,8 +975,7 @@ end)
 
 -------------------------------------------------------------------- cleanup
 
----Resource-stop cleanup: releases NUI focus, deletes props, clears the statebag, stops the clip,
----and stands the seam down so a restarting tablet doesn't leave sd-phone mirroring into nothing.
+---Resource-stop cleanup: releases focus, stops the clip, deletes props and stands the seam down.
 ---@param resource string name of the resource that stopped
 AddEventHandler('onResourceStop', function(resource)
     if resource ~= GetCurrentResourceName() then return end
@@ -984,6 +986,7 @@ AddEventHandler('onResourceStop', function(resource)
         TriggerEvent('sd-phone:client:openState', false)
     end
     stopPose()
-    if cfg.PropVisibleToOthers then LocalPlayer.state:set('sdTablet', false, true) end
+    -- The `sdTablet` bag is the server's to write, and it clears every player's on its own stop.
+    -- Writing false here too would desync it and get the next open deduped away as "no change".
     for source in pairs(remoteProps) do removeRemoteProp(source) end
 end)

--- a/client/rpc.lua
+++ b/client/rpc.lua
@@ -96,7 +96,7 @@ RegisterNUICallback('rpc', function(data, cb)
         end
         local ok, err = pcall(handlers[action], data.payload, answer)
         if not ok then
-            print(('^1[sd-tablet:rpc]^0 %s failed: %s'):format(action, err))
+            lib.print.error(('rpc %s failed: %s'):format(action, err))
             answer({ success = false, message = 'Handler error' })
         end
         return

--- a/configs/tablet.lua
+++ b/configs/tablet.lua
@@ -106,10 +106,8 @@ return {
     PropOffset = vec3(0.0, 0.0, 0.0),
     PropRot    = vec3(0.0, 0.0, 0.0),
 
-    -- Let other players see the tablet in your hands. The holder broadcasts a replicated statebag
-    -- and every nearby client spawns its own LOCAL welded copy (the clip already replicates on
-    -- its own). Deliberately NOT a networked object: a networked prop's ownership can migrate to
-    -- another client whose sync then freezes it mid-hold. Set false for local-only.
+    -- Let other players see the tablet: the server ownership-checks the colour and writes a
+    -- replicated statebag, and every nearby client welds its own LOCAL copy off it.
     PropVisibleToOthers = true,
 
     -- Cosmetic status bar. The tablet keeps its OWN battery - it is a different device with a

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -26,6 +26,10 @@ ui_page 'web/build/index.html'
 files {
     'configs/*.lua',
     'client/**.lua',
+    -- ox_lib's locale module reads these with LoadResourceFile, so they ship as files. Both
+    -- realms call lib.locale(): the client resolves the player's ox_lib language setting, the
+    -- server the `ox:locale` convar.
+    'locales/*.json',
     'web/build/index.html',
     'web/build/components.js',
     'web/build/assets/*.js',

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,10 @@
+{
+    "tablet": "Tablet",
+    "no_tablet": "You don't have a tablet.",
+    "cannot_connect": "The tablet can't connect right now.",
+    "cannot_use": "You can't use your tablet right now.",
+    "cannot_use_swimming": "You can't use your tablet while swimming.",
+    "cannot_use_driving": "Not while you're driving.",
+    "keybind_toggle": "Toggle Tablet",
+    "keybind_look": "Tablet: Hold to look around"
+}

--- a/server/main.lua
+++ b/server/main.lua
@@ -14,25 +14,9 @@ local PHONE <const> = 'sd-phone'
 -- ---------------------------------------------------------------------------
 -- Framework + inventory
 --
--- sd-phone has a full inventory bridge (bridge/server/inventory.lua) and this file needs two
--- lines of it: "does this player hold the item" and "run this when they use it". It is
--- deliberately NOT required across the resource boundary.
---
--- ox_lib's require DOES support it - `require '@sd-phone.bridge.server.inventory'` resolves,
--- because package.searchpath pulls the named resource out of the module path and LoadResourceFile
--- reads it, and nested requires inside the loaded chunk resolve back into sd-phone because the
--- chunk is loaded under an `@@sd-phone/...` name. It is still the wrong thing to do:
---
---   * package.loaded is per-Lua-state, so sd-tablet would get its own second copy of the module
---     and of everything it pulls in - re-running bridge/shared/framework.lua (which PRINTS a
---     "[SD-PHONE] Framework detected" banner and hard-errors when no framework is up) and
---     bridge/server/player.lua (which registers playerDropped and character-lifecycle handlers,
---     and would keep a second, redundant identity cache).
---   * it welds this resource to sd-phone's internal file layout, which is private and moves.
---
--- Two functions' worth of duplication is the cheaper trade. The backend list and the call shapes
--- are kept identical to sd-phone's bridge on purpose: if a server's inventory works there, it
--- works here.
+-- Two functions duplicated rather than required across the resource boundary: package.loaded is
+-- per-Lua-state, so requiring sd-phone's bridge would re-run its framework banner and register a
+-- second set of player handlers. Call shapes are kept identical to sd-phone's on purpose.
 -- ---------------------------------------------------------------------------
 
 ---@class TabletFramework
@@ -90,8 +74,7 @@ local function getPlayer(src)
     return framework.core.GetPlayerFromId(src)
 end
 
----Pick the inventory backend's count-of-item implementation once at load. Every path answers 0,
----never nil, when the player or item can't be resolved.
+---Picks the backend's count-of-item implementation once at load; every path answers 0, never nil.
 ---@return fun(source: number, item: string): number
 local function chooseCount()
     if active == 'ox_inventory' then
@@ -123,8 +106,7 @@ local function chooseCount()
         return function(src, item) return exports['qb-inventory']:GetItemCount(src, item) or 0 end
     end
 
-    -- ps-inventory / lj-inventory and the no-inventory-resource case all resolve through the
-    -- framework's own player object, which those forks keep authoritative.
+    -- ps/lj-inventory and the no-inventory case resolve through the framework's own player object.
     if framework and framework.name == 'esx' then
         return function(src, item)
             local p = getPlayer(src); if not p then return 0 end
@@ -145,9 +127,8 @@ end
 ---@type fun(source: number, item: string): number Backend item-count reader, bound once at load.
 local countItem = chooseCount()
 
----Pick the "register a usable item" implementation once at load. The ox path derives a per-item
----export ('tablet' -> 'useTablet') on THIS resource, which is why the ox_inventory item
----definition in the README points at `sd-tablet.useTablet`.
+---Picks the usable-item registrar once at load; the ox path derives a per-item export on THIS
+---resource ('tablet' -> 'useTablet'), which is what the README's ox_inventory definition points at.
 ---@return fun(item: string, cb: fun(source: number)): nil
 local function chooseRegisterUsable()
     if active == 'ox_inventory' then
@@ -186,14 +167,11 @@ local registerUsable = chooseRegisterUsable()
 -- ---------------------------------------------------------------------------
 -- SIM mode
 --
--- Under sd-phone's unique-phones/SIM mode the acting identity comes from the SIM in the player's
--- ACTIVE PHONE, so a tablet - which has no SIM tray and no device identity - has no identity to
--- act as. Rather than open a device that shows the wrong data, both open paths refuse.
---
--- isSimModeActive is a SERVER export, and sd-phone only flips the flag several seconds into boot,
--- after it has waited for the inventory to start and probed it for per-slot metadata support. So
--- the flag is polled until it settles rather than read once, and mirrored into global state for
--- the client, which has no export of its own to ask.
+-- No longer a refusal: the tablet borrows the identity of the SIM in the phone the player carries,
+-- exactly as it borrows everything else, so a request already answers as the right number. The flag
+-- survives only to reach the UI, which needs it to tell "no SIM" apart from "this server has none".
+-- sd-phone flips it seconds into boot behind an inventory probe, so it is polled until it settles
+-- and mirrored into global state for the client, which has no export of its own to ask.
 -- ---------------------------------------------------------------------------
 
 ---@return boolean
@@ -205,14 +183,12 @@ end
 
 CreateThread(function()
     GlobalState.sdTabletSimMode = false
-    -- 60s of polling covers sd-phone's own probe (up to ~10s of waiting for ox_inventory, plus a
-    -- schema ensure) with room to spare on a slow boot. The flag is set once and never cleared,
-    -- so the first true is final.
+    -- 60s covers sd-phone's own probe with room to spare; the first true is final.
     for _ = 1, 30 do
         if simModeActive() then
             GlobalState.sdTabletSimMode = true
-            print('^3[sd-tablet]^0 sd-phone is running unique phones / SIM cards - the tablet stays closed. '
-                .. 'A tablet has no SIM, so it has no identity to act as.')
+            print('^3[sd-tablet]^0 sd-phone is running unique phones / SIM cards - the tablet acts '
+                .. 'as the SIM in the phone the player is carrying.')
             return
         end
         Wait(2000)
@@ -221,27 +197,72 @@ end)
 
 -- ---------------------------------------------------------------------------
 -- Ownership
+--
+-- Resolving a colour searches the inventory once per configured item, and every caller is
+-- client-reachable at whatever rate it likes - so the OWNED SET is cached per player for a short
+-- window. The set rather than the resolved colour: caching the answer would key it on the
+-- client-supplied `preferred`, which a client could vary to miss the cache every time.
 -- ---------------------------------------------------------------------------
 
----The colour of a tablet item this player actually carries, preferring the one they last opened
----with so the keybind keeps handing back the same device.
+---@type integer ms an owned-colour set stays good for; long enough to collapse a burst.
+local OWNERSHIP_TTL <const> = 3000
+
+---@type table<number, { at: integer, colors: string[] }> Server id -> cached owned set.
+local ownershipCache = {}
+
+---Every configured colour this player currently carries, in config order.
+---@param source number player server id
+---@return string[] colors
+local function ownedColors(source)
+    local now = GetGameTimer()
+    local hit = ownershipCache[source]
+    if hit and now - hit.at < OWNERSHIP_TTL then return hit.colors end
+
+    local colors, seen = {}, {}
+    for _, entry in ipairs(cfg.Items or {}) do
+        -- Several items map to one colour, so a colour already found needs no second search.
+        if not seen[entry.color] and countItem(source, entry.item) > 0 then
+            seen[entry.color] = true
+            colors[#colors + 1] = entry.color
+        end
+    end
+
+    ownershipCache[source] = { at = now, colors = colors }
+    return colors
+end
+
+---Drops a player's cached owned set, so the next read goes back to the inventory.
+---@param source number player server id
+local function invalidateOwnership(source)
+    ownershipCache[source] = nil
+end
+
+---The colour this player carries, preferring their last-opened one so the keybind stays stable.
 ---@param source number player server id
 ---@param preferred string|nil last-used colour hint from the client
 ---@return string|nil color colour to open with, nil when no tablet item is owned
 local function resolveOwnedColor(source, preferred)
-    local items = cfg.Items or {}
+    local colors = ownedColors(source)
+    if #colors == 0 then return nil end
     if preferred then
-        for _, entry in ipairs(items) do
-            if entry.color == preferred and countItem(source, entry.item) > 0 then
-                return entry.color
-            end
+        for i = 1, #colors do
+            if colors[i] == preferred then return preferred end
         end
     end
-    for _, entry in ipairs(items) do
-        if countItem(source, entry.item) > 0 then return entry.color end
-    end
-    return nil
+    return colors[1]
 end
+
+---Clamps a client-supplied colour hint to something safe to compare against a config value.
+---@param value any
+---@return string|nil
+local function cleanColor(value)
+    if type(value) ~= 'string' or value == '' or #value > 32 then return nil end
+    return value
+end
+
+AddEventHandler('playerDropped', function()
+    invalidateOwnership(source)
+end)
 
 ---Whether a player may open a tablet right now, and in which colour.
 ---@param source number player server id
@@ -250,9 +271,8 @@ end
 ---@return string|nil message reason to show when refused
 ---@return string|nil color colour to open with
 local function mayOpen(source, preferred)
-    if simModeActive() then
-        return false, 'This server uses SIM cards - a tablet has no SIM. Use your phone.'
-    end
+    -- No SIM check: the identity comes from the SIM in the phone they carry, so this answers as
+    -- the right number either way, and with none the shared UI shows its own No Service screen.
     if not cfg.Items or cfg.RequireItem == false then
         return true, nil, resolveOwnedColor(source, preferred) or cfg.DefaultColor
     end
@@ -261,39 +281,137 @@ local function mayOpen(source, preferred)
     return false, 'You don\'t have a tablet.'
 end
 
----Keybind open request: may this player open a tablet, and in which colour? The client asks before
----every open, so the item check is authoritative in the only place it can be - a client-side check
----is a suggestion.
+---Keybind open request; the item check is authoritative here because a client-side one is only a
+---suggestion. `preferred` is client-supplied, so it is clamped and the cost bounded by the cache.
 lib.callback.register('sd-tablet:server:resolveOpen', function(source, preferred)
-    local ok, message, color = mayOpen(source, preferred)
+    local ok, message, color = mayOpen(source, cleanColor(preferred))
     return { ok = ok, message = message, color = color }
 end)
 
--- Boot: registers every usable tablet item once. Deferred a tick like sd-phone's, so the inventory
--- resource's own exports exist by the time we hand it a callback.
+-- ---------------------------------------------------------------------------
+-- Hold broadcast
+--
+-- Nearby clients weld a local prop copy off the replicated `sdTablet` player bag. The bag is
+-- written HERE because a client can write its own, so a client-written colour would be the item
+-- check with the item removed - and every change costs each observer a prop delete + spawn.
+-- Writes are coalesced rather than dropped: a stow arriving inside the window still has to land,
+-- or the prop is stranded in every observer's view until the player next opens the tablet.
+-- ---------------------------------------------------------------------------
+
+if cfg.PropVisibleToOthers then
+    ---@type integer Minimum ms between bag writes for one player; a real hold never bursts.
+    local HOLD_MIN_INTERVAL <const> = 400
+
+    ---@type table<string, true> Colours any configured item can open, for the no-item-check case.
+    local CONFIGURED_COLORS = {}
+    for _, entry in ipairs(cfg.Items or {}) do CONFIGURED_COLORS[entry.color] = true end
+    if cfg.DefaultColor then CONFIGURED_COLORS[cfg.DefaultColor] = true end
+
+    ---@class HoldState
+    ---@field at integer game time of the last write
+    ---@field value string|false what is on the bag now
+    ---@field pending string|false value waiting for the window to expire
+    ---@field hasPending boolean `pending` is meaningful (false is a legal value, so nil won't do)
+    ---@field queued boolean a timer is already armed to flush `pending`
+
+    ---@type table<number, HoldState>
+    local holdState = {}
+
+    ---Writes the bag and stamps the window.
+    ---@param src number
+    ---@param state HoldState
+    ---@param value string|false
+    local function applyHold(src, state, value)
+        state.at    = GetGameTimer()
+        state.value = value
+        Player(src).state:set('sdTablet', value, true)
+    end
+
+    ---Resolves what this player may claim to be holding.
+    ---@param src number
+    ---@param color any client-supplied colour, or false/nil to stow
+    ---@return string|false|nil value bag value to write, nil to ignore the request entirely
+    local function resolveHold(src, color)
+        if color == nil or color == false then return false end
+
+        local clean = cleanColor(color)
+        if not clean then return nil end
+
+        -- Item check off: any configured colour is an honest claim. On: they must hold it.
+        if not cfg.Items or cfg.RequireItem == false then
+            return CONFIGURED_COLORS[clean] and clean or nil
+        end
+        return resolveOwnedColor(src, clean) == clean and clean or false
+    end
+
+    RegisterNetEvent('sd-tablet:server:setHolding', function(color)
+        local src = source
+        local value = resolveHold(src, color)
+        if value == nil then return end
+
+        local state = holdState[src]
+        if not state then
+            state = { at = 0, value = false, hasPending = false, queued = false }
+            holdState[src] = state
+        end
+
+        -- Already what the bag says; costs observers nothing, so drop it whatever the rate.
+        if state.value == value then
+            state.hasPending = false
+            return
+        end
+
+        local wait = HOLD_MIN_INTERVAL - (GetGameTimer() - state.at)
+        if wait <= 0 then
+            state.hasPending = false
+            return applyHold(src, state, value)
+        end
+
+        -- Inside the window: keep the latest value and let one armed timer apply it.
+        state.pending    = value
+        state.hasPending = true
+        if state.queued then return end
+        state.queued = true
+        SetTimeout(wait, function()
+            local cur = holdState[src]
+            if not cur then return end
+            cur.queued = false
+            if not cur.hasPending then return end
+            cur.hasPending = false
+            local pending = cur.pending
+            if pending ~= cur.value then applyHold(src, cur, pending) end
+        end)
+    end)
+
+    AddEventHandler('playerDropped', function()
+        holdState[source] = nil
+    end)
+
+    -- Restarting leaves every holder's bag set with no observer left to clean it up.
+    AddEventHandler('onResourceStop', function(resource)
+        if resource ~= GetCurrentResourceName() then return end
+        for _, id in ipairs(GetPlayers()) do
+            local src = tonumber(id)
+            if src then Player(src).state:set('sdTablet', false, true) end
+        end
+    end)
+end
+
+-- Boot: registers every usable tablet item once, deferred a tick so the inventory's exports exist.
 CreateThread(function()
     Wait(50)
     if not cfg.Items then return end
     for _, entry in ipairs(cfg.Items) do
         registerUsable(entry.item, function(source)
-            -- No ownership check here: using the item IS the proof. The SIM refusal still applies,
-            -- and is answered with a toast rather than silence so the player knows why nothing
-            -- opened.
-            if simModeActive() then
-                TriggerClientEvent('ox_lib:notify', source, {
-                    title       = 'Tablet',
-                    description = 'This server uses SIM cards - a tablet has no SIM. Use your phone.',
-                    type        = 'error',
-                })
-                return
-            end
+            -- Using an item can consume or move it, so the cached set is now a guess.
+            invalidateOwnership(source)
+            -- No ownership check: using the item IS the proof.
             TriggerClientEvent('sd-tablet:client:openFromItem', source, entry.color)
         end)
     end
 end)
 
----Public export: does this player own a tablet - exports['sd-tablet']:hasTablet(source). Stays
----boolean rather than returning the colour, because callers already treat it as a yes/no.
+---Public export: does this player own a tablet - exports['sd-tablet']:hasTablet(source).
 ---@param source number player server id
 ---@return boolean
 exports('hasTablet', function(source)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,7 +1,9 @@
+lib.locale()
+
 -- Build-presence guard: a source checkout without a compiled NUI would open to a blank tablet.
 if not LoadResourceFile(GetCurrentResourceName(), 'web/build/index.html') then
-    print('^1[sd-tablet] NUI build not found at web/build/index.html.^0')
-    print('^3[sd-tablet] Build it: cd web && bun install && bun run build^0')
+    lib.print.error('NUI build not found at web/build/index.html.')
+    lib.print.warn('Build it: cd web && bun install && bun run build')
 end
 
 ---@type table sd-tablet config root (configs/config.lua).
@@ -157,7 +159,7 @@ local function chooseRegisterUsable()
     end
 
     return function(item)
-        print(('^1[sd-tablet] no supported registration path for usable item %q - open it with the keybind.^0'):format(item))
+        lib.print.error(('no supported registration path for usable item %q - open it with the keybind.'):format(item))
     end
 end
 
@@ -187,8 +189,8 @@ CreateThread(function()
     for _ = 1, 30 do
         if simModeActive() then
             GlobalState.sdTabletSimMode = true
-            print('^3[sd-tablet]^0 sd-phone is running unique phones / SIM cards - the tablet acts '
-                .. 'as the SIM in the phone the player is carrying.')
+            lib.print.info('sd-phone is running unique phones / SIM cards - the tablet acts as the '
+                .. 'SIM in the phone the player is carrying.')
             return
         end
         Wait(2000)
@@ -244,11 +246,7 @@ end
 local function resolveOwnedColor(source, preferred)
     local colors = ownedColors(source)
     if #colors == 0 then return nil end
-    if preferred then
-        for i = 1, #colors do
-            if colors[i] == preferred then return preferred end
-        end
-    end
+    if preferred and lib.table.contains(colors, preferred) then return preferred end
     return colors[1]
 end
 
@@ -278,7 +276,7 @@ local function mayOpen(source, preferred)
     end
     local color = resolveOwnedColor(source, preferred)
     if color then return true, nil, color end
-    return false, 'You don\'t have a tablet.'
+    return false, locale('no_tablet')
 end
 
 ---Keybind open request; the item check is authoritative here because a client-side one is only a
@@ -432,6 +430,6 @@ exports('tabletColor', function(source)
 end)
 
 if not framework then
-    print('^1[sd-tablet] No supported framework detected (qbx_core / qb-core / es_extended). '
-        .. 'The item check will refuse every open.^0')
+    lib.print.error('No supported framework detected (qbx_core / qb-core / es_extended). '
+        .. 'The item check will refuse every open.')
 end

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -10,19 +10,19 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "html2canvas": "1.4.1",
-        "lucide-react": "0.577.0",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
+        "lucide-react": "1.26.0",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "zustand": "5.0.14",
       },
       "devDependencies": {
-        "@types/react": "18.3.31",
-        "@types/react-dom": "18.3.7",
+        "@types/react": "19.2.17",
+        "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.4",
         "autoprefixer": "10.5.4",
         "postcss": "8.5.22",
         "tailwindcss": "3.4.19",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
         "vite": "8.1.5",
       },
     },
@@ -92,11 +92,49 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
-    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
-    "@types/react": ["@types/react@18.3.31", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw=="],
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.4", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg=="],
 
@@ -180,8 +218,6 @@
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
     "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
@@ -210,9 +246,7 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
-
-    "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
+    "lucide-react": ["lucide-react@1.26.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-raglYVR2+VkMfJL158krjVmE+rV5ST2lzA/KQm1FRSjMHT4MnWaegHxoVEpmc2So3nOEhp9oGejJwAPX8MoAjg=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -256,9 +290,9 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
-    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
@@ -272,7 +306,7 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -296,7 +330,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -23,7 +23,12 @@ export default defineConfig({
     // The locale catalogs are globbed relative to sd-phone's own i18n source file, so they
     // resolve to sd-phone/locales and rollup bundles them without help. The dev server serves
     // files, not bundles, so it needs both resource roots on its allowlist.
-    server: { fs: { allow: ['..', phoneRoot] } },
+    // That allowlist serves all of sd-tablet AND sd-phone over HTTP, so the bind is pinned to
+    // loopback rather than left to the default. Never run this dev server with --host.
+    server: {
+        host: '127.0.0.1',
+        fs: { allow: ['..', phoneRoot] },
+    },
     build: {
         // FiveM's CEF and the dev browser (Edge) are both modern Chromium, so
         // skip downleveling to the generic es2020 baseline.


### PR DESCRIPTION
## What

Moves the tablet's client and server onto ox_lib's modules, and finishes the server half of "open on SIM servers".

## ox_lib

Hand-rolled natives swapped for the tested equivalents:

| Was | Now |
| --- | --- |
| `RequestModel` + `HasModelLoaded` poll loop | `lib.requestModel` |
| `RequestAnimDict` + wait loop + `TaskPlayAnim` | `lib.playAnim` |
| `PlayerPedId()` / `PlayerId()` repeated | `cache.ped`, `cache.playerId`, `cache.serverId` |
| `IsPedInAnyVehicle` + `GetPedInVehicleSeat` driver check | `cache.vehicle` + `cache.seat` |
| paired `RegisterCommand` / `RegisterKeyMapping` | `lib.addKeybind` |
| `TriggerClientEvent('ox_lib:notify', ...)` | `lib.notify` (server) |

`lib.playAnim` also releases the anim dict when it's done, which the old path never did.

Two spots deliberately kept hand-rolled, because ox_lib is the worse fit:

- the SIM boot poll — `lib.waitFor` spins at `Wait(0)`, so against a 60s budget it's far more expensive than the existing `Wait(2000)` loop
- the server ownership TTL cache — ox_lib's `cache(key, fn, timeout)` has no invalidation, and this one has to be dropped on item use and on `playerDropped`

## SIM servers

`a0e820e` removed the client-side refusal, but three more were left on the server. `resolveOpen` still rejected, so the tablet never actually opened on a SIM server — the refusal toast just came from somewhere else.

Removed from `mayOpen` and from the usable-item path, and the boot notice no longer says "the tablet stays closed".

The flag itself stays. `sim.enabled` still rides in the open payload, because the shared UI needs it to tell "no SIM in the phone you're carrying" apart from "this server doesn't use SIMs" — the same reason `a0e820e` stopped dropping `sd-phone:simState`.

## Also

- **Dev server pinned to loopback.** `server.fs.allow` exposes both the sd-tablet and sd-phone trees over HTTP, `sd-phone/server/**` included. That's fine on localhost and not fine on the default bind.
- **`web/bun.lock` regenerated.** It was still pinned to React 18 after `package.json` moved to React 19, so the lockfile and the manifest disagreed.
- Long comment blocks collapsed to one line each.

## Testing

- `luac -p` passes on every changed Lua file
- `bun run build` is green — `tsc --noEmit` clean, `vite build` succeeds

Not exercised at runtime; the ox_lib call sites want a server start to confirm in-game behaviour.

## Note

The typecheck only passes with sd-phone up to date. On an older sd-phone it fails on duplicate `@types/react` (React 18 vs 19) and on `defaultScale` missing from `DeviceProfile`.
