### PR TITLE
feat(pose): export mirrorPoseOnto so a stand-in ped keeps the tablet pose

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -326,6 +326,33 @@ local function playPose()
     end)
 end
 
+---Puts the hold pose and a matching prop onto ANOTHER ped, and hands the prop back.
+---
+---For the stand-in sd-phone's MDT leaves behind while a dispatcher watches a camera: the officer
+---is stood there holding a tablet, so the copy has to be holding one too rather than appearing
+---empty-handed the moment somebody opens a feed.
+---
+---The prop is returned rather than tracked here, because it belongs to the ped the caller owns and
+---has to be deleted with it. This resource only ever tracks the player's own.
+---@param ped integer the ped to put the pose on
+---@return integer|nil prop the prop welded to it, for the caller to delete
+local function mirrorPoseOnto(ped)
+    if not shouldHold() then return nil end
+    if not ped or ped == 0 or not DoesEntityExist(ped) then return nil end
+
+    if pcall(lib.requestAnimDict, cfg.AnimDict, 1000) then
+        -- A plain looping FULL BODY clip, not the upper-body secondary the player gets. That one
+        -- blends over whatever the ped is already doing, and a stand-in that has just been cloned
+        -- and stood still has nothing underneath for it to blend onto, so it barely reads at all.
+        TaskPlayAnim(ped, cfg.AnimDict, cfg.AnimName, 8.0, -8.0, -1, 1, 0.0, false, false, false)
+        RemoveAnimDict(cfg.AnimDict)
+    end
+
+    return createProp(ped, currentColor)
+end
+
+exports('mirrorPoseOnto', mirrorPoseOnto)
+
 ---Stops our clip and removes the prop.
 local function stopPose()
     local ped = cache.ped


### PR DESCRIPTION
Companion to sd-phone [#234](https://github.com/Samuels-Development/sd-phone/pull/234).

The MDT's Cameras section leaves a **stand-in ped** where an officer was standing while a dispatcher watches their camera, because rendering a remote camera means travelling to that officer and the body would otherwise visibly vanish in front of their colleagues.

The officer is holding a tablet at that moment, since that is how they opened the camera. This resource owns its own hold clip and prop, so it has to answer for itself: sd-phone cannot know what a tablet looks like in a hand.

`mirrorPoseOnto(ped)` plays the hold clip on the given ped, welds a matching prop, and hands the prop back for the caller to delete with the ped. It returns nil when the tablet is not actually being held, which is what lets sd-phone ask the phone first and fall through to here.

Two details worth noting:

- The clip is played as a plain looping **full body** animation rather than the upper-body secondary the player gets. That one blends over whatever the ped is already doing, and a freshly cloned ped standing still has nothing underneath for it to blend onto, so it barely reads.
- The prop is **returned, not tracked**. It belongs to a ped this resource does not own, and tracking it here would tangle it with the player's own on cleanup.

Nothing else changes: no new state, no new tick, and the export is inert unless sd-phone calls it.
