### PR TITLE
feat(minesweeper): list Minesweeper in the tablet app catalog

### DIFF
--- a/configs/apps.lua
+++ b/configs/apps.lua
@@ -93,6 +93,7 @@ return {
         { id = 'wordle', label = 'Wordle', icon = 'wordle', route = '/wordle', accent = '#6AAA64', base = false, enabled = true },
         { id = 'flappy', label = 'Flappy', icon = 'flappy', route = '/flappy', accent = '#4EC0CA', base = false, enabled = true },
         { id = 'blocks', label = 'Blocks', icon = 'blocks', route = '/blocks', accent = '#7C4DFF', base = false, enabled = true },
+        { id = 'minesweeper', label = 'Minesweeper', icon = 'minesweeper', route = '/minesweeper', accent = '#E4483D', base = false, enabled = true },
         { id = 'blackjack', label = 'Blackjack', icon = 'blackjack', route = '/blackjack', accent = '#157347', base = false, enabled = true },
         { id = 'climber', label = 'Climber', icon = 'climber', route = '/climber', accent = '#8BC34A', base = false, enabled = true },
         { id = 'railrunner', label = 'Rail Runner', icon = 'railrunner', route = '/railrunner', accent = '#3C5290', base = false, enabled = false },


### PR DESCRIPTION
Lists Minesweeper in the tablet's app catalog so it appears alongside the other games on the second device.

The game itself lives in sd-phone (`web/src/apps/minesweeper/`), which the tablet compiles against; this repo only owns its own `Apps` catalog, so a game is invisible here until it has a row.

Pairs with Samuels-Development/sd-phone#257 — merge that first, since the route resolves to sd-phone's registry.

The tablet bundle has been rebuilt and contains the `Minesweeper-*.js` chunk. `sd-tablet` restarts clean.

**Not verified:** the game's layout at tablet geometry. It was played and checked at phone geometry only.
