### PR TITLE
chore(release): 0.9.12

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 'yes'
 
 name 'sd-tablet'
 author 'Samuel#0008'
-version '0.9.8'
+version '0.9.12'
 description 'In-game tablet: a second device running the sd-phone React bundle over sd-phone\'s own client and server layer. Shares every byte of player data with the phone - messages, mail, contacts, installed apps, settings - and can do everything the phone can except make or receive voice calls'
 
 shared_scripts {


### PR DESCRIPTION
Version bump for the v0.9.12 pair release: `fxmanifest.lua` 0.9.8 -> 0.9.12.

The jump skips 0.9.9-0.9.11 deliberately. `.github/workflows/release.yml` checks out sd-phone at the **tablet's own tag**, and the tablet has no UI source of its own (`web/vite.config.ts` aliases `@` at `../../sd-phone/web/src`), so the tag is really a pair version. Cutting 0.9.9 would have built this against sd-phone v0.9.9 from 2026-08-28 - which has no Minesweeper app, while `configs/apps.lua` here now lists one, so the tablet would have shipped an icon that opens nothing.

`web/package.json` stays at 0.1.0; it is not the release version in this repo.

Pairs with Samuels-Development/sd-phone#260. sd-phone's v0.9.12 tag must exist before this repo's release is published, or the workflow's sd-phone checkout will fail.