### PR TITLE
chore(release): back out the 0.9.12 bump

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 'yes'
 
 name 'sd-tablet'
 author 'Samuel#0008'
-version '0.9.12'
+version '0.9.8'
 description 'In-game tablet: a second device running the sd-phone React bundle over sd-phone\'s own client and server layer. Shares every byte of player data with the phone - messages, mail, contacts, installed apps, settings - and can do everything the phone can except make or receive voice calls'
 
 shared_scripts {


### PR DESCRIPTION
Reverts #5. The v0.9.12 release and tag were deleted, so `fxmanifest.lua` goes back to 0.9.8.

Pairs with Samuels-Development/sd-phone#261. The Minesweeper catalog row and the other changes since v0.9.8 stay on main; only the version string moves.