### PR TITLE
feat(i18n): Add Croatian locale

### DIFF
--- a/locales/hr.json
+++ b/locales/hr.json
@@ -1,0 +1,10 @@
+{
+  "tablet": "Tablet",
+  "no_tablet": "Nemaš tablet.",
+  "cannot_connect": "Tablet se trenutačno ne može povezati.",
+  "cannot_use": "Trenutačno ne možeš koristiti tablet.",
+  "cannot_use_swimming": "Ne možeš koristiti tablet dok plivaš.",
+  "cannot_use_driving": "Ne možeš koristiti tablet dok voziš.",
+  "keybind_toggle": "Otvori/zatvori tablet",
+  "keybind_look": "Tablet: drži za pogled oko sebe"
+}


### PR DESCRIPTION
This PR adds the Croatian (\hr.json\) locale file to \sd-tablet\.&#13;&#10;&#13;&#10;* The translations are free of diacritics (using c, s, z instead of č, ć, š, ž, đ) to ensure perfect display across all in-game fonts.&#13;&#10;* Matches the exact structure of \n.json\.&#13;&#10;&#13;&#10;Thank you!